### PR TITLE
Add note about payment confirmation screen

### DIFF
--- a/1.x/introduction.md
+++ b/1.x/introduction.md
@@ -56,6 +56,6 @@ No. Spark only supports Stripe and Paddle and it is not possible for developers 
 
 No. Spark's billing portal is totally isolated from the rest of your Laravel application and includes its own pre-compiled frontend assets. Your own application may be built using the frontend technologies of your choice.
 
-#### **Why are my customers presented with a strange payment confirmation screen?**
+#### **Why are my customers presented with a payment confirmation screen?**
 
-Often extra verification is required in order to confirm and process a payment. When this happens, Paddle or Stripe will present a payment confirmation screen. Payment confirmation screens presented by Paddle, Stripe or Spark may be tailored to a specific bank or card issuer's payment flow and can include additional card confirmation, a temporary small charge, separate device authentication, or other forms of verification.
+Extra verification is sometimes required in order to confirm and process a payment. When this happens, Paddle or Stripe will present a payment confirmation screen. Payment confirmation screens presented by Paddle, Stripe, or Spark may be tailored to a specific bank or card issuer's payment flow and can include additional card confirmation, a temporary small charge, separate device authentication, or other forms of verification.


### PR DESCRIPTION
Related to https://github.com/laravel/docs/pull/6990

I've had this remark from people using Spark. Think it's good to just add a note about this in the Spark docs that these screens are normal and depend on the issuer/bank. 

I wasn't entirely sure where to put this so I added it to the FAQ.