### PR TITLE
Fix formatting in customization.md

### DIFF
--- a/1.x/spark-stripe/customization.md
+++ b/1.x/spark-stripe/customization.md
@@ -71,7 +71,7 @@ This command will publish a `resources/lang/spark/en.json` file containing trans
 
 Most commonly, applications bill individual users for monthly and yearly subscription plans. However, your application may choose to bill some other type of model, such as a team, organization, band, etc.
 
-In that case, you should add `Spark::ignoreMigrations()` in the register method of your application's `App\Providers\SparkServiceProvider` class:
+In that case, you should add `Spark::ignoreMigrations()` in the `register` method of your application's `App\Providers\SparkServiceProvider` class:
 
 ```php
 use Spark\Spark;

--- a/2.x/spark-stripe/customization.md
+++ b/2.x/spark-stripe/customization.md
@@ -71,7 +71,7 @@ This command will publish a `resources/lang/spark/en.json` file containing trans
 
 Most commonly, applications bill individual users for monthly and yearly subscription plans. However, your application may choose to bill some other type of model, such as a team, organization, band, etc.
 
-In that case, you should add `Spark::ignoreMigrations()` in the register method of your application's `App\Providers\SparkServiceProvider` class:
+In that case, you should add `Spark::ignoreMigrations()` in the `register` method of your application's `App\Providers\SparkServiceProvider` class:
 
 ```php
 use Spark\Spark;


### PR DESCRIPTION
Add markdown formatting to `register` method name in `*/spark-stripe/customization.md`