### PR TITLE
Stress urgency about upgrading webhook

### DIFF
--- a/2.x/spark-stripe/upgrade.md
+++ b/2.x/spark-stripe/upgrade.md
@@ -24,9 +24,9 @@ If you use the Stripe SDK directly, make sure to properly test your integration 
 
 #### Upgrading Your Stripe Webhook
 
-:::danger Timing your upgrade
+:::danger Deployment & Webhooks
 
-It's very important that when you deploy your new Spark upgrade, that you upgrade your webhook immediately after deployment, to minimize conflicts where the API version of your webhook is a mismatch with the one used by Cashier.
+It's very important that you upgrade your webhook immediately after updating and deploying Spark in order to minimize conflicts where the API version of your webhook does not match the version used by Cashier.
 :::
 
 You should ensure your Stripe webhook operates on the same API version as Spark's underlying API version used by Cashier. To do so, you may use the `cashier:webhook` command from your production environment to create a new webhook that matches Cashier's Stripe API version:

--- a/2.x/spark-stripe/upgrade.md
+++ b/2.x/spark-stripe/upgrade.md
@@ -24,6 +24,11 @@ If you use the Stripe SDK directly, make sure to properly test your integration 
 
 #### Upgrading Your Stripe Webhook
 
+:::danger Timing your upgrade
+
+It's very important that when you deploy your new Spark upgrade, that you upgrade your webhook immediately after deployment, to minimize conflicts where the API version of your webhook is a mismatch with the one used by Cashier.
+:::
+
 You should ensure your Stripe webhook operates on the same API version as Spark's underlying API version used by Cashier. To do so, you may use the `cashier:webhook` command from your production environment to create a new webhook that matches Cashier's Stripe API version:
 
 ```bash


### PR DESCRIPTION
It should be stressed that this needs to happen immediately after deploying the new version of Spark.