### PR TITLE
v3 docs

### DIFF
--- a/.vuepress/3.x.js
+++ b/.vuepress/3.x.js
@@ -1,0 +1,42 @@
+module.exports = [
+    {
+        title: "Getting Started",
+        collapsable: false,
+        children: [
+            'introduction',
+            'installation',
+            'customization'
+        ],
+    }, {
+        title: "Spark Paddle",
+        collapsable: false,
+        children: prefix('spark-paddle', [
+            'configuration',
+            'plans',
+            'middleware',
+            'events',
+            'testing',
+            'cookbook',
+            'customization',
+            'upgrade',
+        ]),
+    }, {
+        title: "Spark Stripe",
+        collapsable: false,
+        children: prefix('spark-stripe', [
+            'configuration',
+            'plans',
+            'middleware',
+            'taxes',
+            'events',
+            'testing',
+            'cookbook',
+            'customization',
+            'upgrade',
+        ]),
+    }
+]
+
+function prefix(prefix, children) {
+    return children.map(child => `${prefix}/${child}`)
+}

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -33,13 +33,15 @@ module.exports = {
                 items: [
                     { text: "1.x", link: "/1.x/" },
                     { text: "2.x", link: "/2.x/" },
+                    { text: "3.x", link: "/3.x/" },
                 ]
             }
         ],
 
         sidebar: {
             '/1.x/': require('./1.x'),
-            '/2.x/': require('./2.x')
+            '/2.x/': require('./2.x'),
+            '/3.x/': require('./3.x')
         },
     },
 }

--- a/3.x/README.md
+++ b/3.x/README.md
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0;url=/docs/2.x/introduction.html" />

--- a/3.x/customization.md
+++ b/3.x/customization.md
@@ -1,0 +1,13 @@
+# Customization
+
+[[toc]]
+
+## Custom Information Messages
+
+When redirecting to your application's billing portal, you may provide an optional, informational message to give the user context regarding why they are being redirected to the portal. For example, you may provide a message indicating that their subscription has expired.
+
+To provide a message, simply provide a `message` query string parameter to the billing portal. The provided message will appear at the top of your application's billing portal:
+
+```
+http://localhost/billing?message=Hello+World
+```

--- a/3.x/installation.md
+++ b/3.x/installation.md
@@ -1,0 +1,102 @@
+# Installation
+
+[[toc]]
+
+## Installing Spark Via Composer
+
+:::tip License
+
+Before installing Spark, you will need to purchase a [Spark license](https://spark.laravel.com/licenses). You can purchase a Spark license via the Spark dashboard.
+:::
+
+To get started installing Spark, add the Spark repository to your application's `composer.json` file:
+
+```json
+"repositories": [
+    {
+        "type": "composer",
+        "url": "https://spark.laravel.com"
+    }
+],
+```
+
+Next, you may add the `laravel/spark-paddle` or `laravel/spark-stripe` package to the list of required packages in your `composer.json` file:
+
+```json
+"require": {
+    "php": "^8.0",
+    "laravel/framework": "^9.0",
+    "laravel/spark-paddle": "^2.0"
+},
+```
+
+After your `composer.json` file has been updated, run the `composer update` command in your console terminal:
+
+```bash
+composer update
+```
+
+When running `composer update`, you will be prompted to provide your login credentials for the Spark website. These credentials will authenticate your Composer session as having permission to download the Spark source code. To avoid manually typing these credentials, you may create a [Composer auth.json file](https://getcomposer.org/doc/articles/http-basic-authentication.md) and use your [API token](https://spark.laravel.com/user/api-tokens) in place of your password:
+
+```json
+{
+    "http-basic": {
+        "spark.laravel.com": {
+            "username": "taylor@example.com",
+            "password": "your-api-token"
+        }
+    }
+}
+```
+
+You may quickly create an `auth.json` file via your terminal using the following command. As mentioned previously, you may create an API token via the [Spark dashboard](https://spark.laravel.com/user/api-tokens). This token may be used as a substitute for your password when creating a Composer `auth.json` file:
+
+```bash
+composer config http-basic.spark.laravel.com taylor@example.com your-api-token
+```
+
+:::danger The `auth.json` File
+
+You should not commit your application's `auth.json` file into source control.
+:::
+
+Once the package is installed via Composer, run the `spark:install` Artisan command:
+
+```bash
+php artisan spark:install
+```
+
+Finally, run the `migrate` Artisan command:
+
+```bash
+php artisan migrate
+```
+
+:::tip Stripe Billables
+
+If you are using the Stripe edition of Spark and plan to bill a model other than the `App\Models\User` model, you should follow [these instructions](./spark-stripe/customization.md#migrations) before running the migration command.
+:::
+
+Lastly, you will need to configure Stripe or Paddle webhooks so that these services can communicate with your local application via webhooks. To get started, read our dedicated documentation on [Stripe webhooks](./spark-stripe/configuration.md#stripe-webhooks) or [Paddle webhooks](./spark-paddle/configuration.md#paddle-webhooks). Webhooks are required during both local development and in production environments.
+
+That's it! Next, you may navigate to your application's `config/spark.php` configuration file and begin configuring your Spark installation.
+
+## Authenticating Spark in Continuous Integration (CI) Environments
+
+It's not advised to store your `auth.json` file inside your project's version control repository. However, there may be times you wish to download Spark inside a CI environment like [Chipper CI](https://chipperci.com/). For instance, you may wish to run tests for any custom tools you create. To authenticate Spark in these situations, you can use Composer to set the configuration option inside your CI system's pipeline, injecting environment variables containing the credentials you use to login to the Spark dashboard and a valid [Spark dashboard API token](https://spark.laravel.com/users/api-tokens):
+
+```sh
+composer config http-basic.spark.laravel.com ${SPARK_USERNAME} ${SPARK_API_TOKEN}
+```
+
+## Expired Licenses
+
+If your Spark license has expired and you don't want to renew the license your `composer.json` file will need to specify the last version of Spark released before your license expired:
+
+```json
+"require": {
+    "php": "^8.0",
+    "laravel/framework": "^9.0",
+    "laravel/spark-paddle": "2.y.z"
+},
+```

--- a/3.x/introduction.md
+++ b/3.x/introduction.md
@@ -1,0 +1,61 @@
+# Introduction
+
+[[toc]]
+
+## Laravel Spark
+
+Laravel Spark is the perfect starting point for your next big idea. When combined with a Laravel application starter kit like [Laravel Jetstream](https://jetstream.laravel.com) or [Laravel Breeze](https://laravel.com/docs/starter-kits), or the frontend of your choice, Spark provides a well-designed billing management panel for your application. Spark, which is built on the power of [Laravel Cashier](https://laravel.com/docs/billing), allows your customers to subscribe to monthly or yearly billing plans, manage their payment method, update their subscription plans, and download their receipts all from a self-contained, beautifully designed billing portal.
+
+<iframe width="600" height="337" src="https://www.youtube.com/embed/-wAmFagQSzI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+## Supported Payment Providers
+
+Spark supports two payment providers, and purchasing a Spark license grants you the ability to use either of these payment providers. **At this time, it is not possible to implement your own custom payment provider when using Spark.** We'll provide a brief overview of each provider below.
+
+### Paddle
+
+[Paddle](https://paddle.com) is a robust billing provider that serves as a merchant of record for your application. Paddle removes the burden of tax compliance from your SaaS business by handling the complexity of gathering and paying your VAT for you. In addition, Paddle provides support for accepting payments from your customers via credit card or PayPal, localized pricing, and hosted invoices.
+
+Spark's Paddle support is provided by the underlying [Laravel Cashier Paddle](https://laravel.com/docs/cashier-paddle) library.
+
+:::warning Paddle Account Approval
+
+Your Paddle account must be approved by Paddle before you can begin using Spark. To apply for an account, please visit the [Paddle website](https://paddle.com). **While you are developing your application, you may use the [Paddle Sandbox](https://developer.paddle.com/getting-started/sandbox)**.
+:::
+
+#### Limitations
+
+We have listed some known limitations of using the Paddle payment provider below:
+
+- When a recurring coupon is used while subscribing to a plan, the coupon discount will be applied on every billing cycle. However, if the subscription's quantity or plan changes, Paddle will remove the coupon from the subscription.
+- Because Paddle does not allow plan quantity changes during trial periods, the Paddle edition of Spark does not support requiring a credit card up front when beginning a trial. All trial periods are started without a credit card or payment method provided up front during the user's initial registration process.
+
+### Stripe
+
+[Stripe](https://stripe.com) is a global leader in payment infrastructure with direct integration with card networks and banks, a fast-improving platform, and battle-tested reliability. In addition, intelligent optimizations help increase revenue across conversion, prevent fraud, and assist with revenue recovery. Finally, Stripe provides a robust sandbox environment for you to test your application's payment system.
+
+Spark's Stripe support is provided by the underlying [Laravel Cashier Stripe](https://laravel.com/docs/billing) library.
+
+#### Limitations
+
+We have listed some known limitations of using the Stripe payment provider below:
+
+- The Stripe payment provider does not provide a PayPal integration.
+
+## Frequently Asked Questions
+
+#### **Is it possible to upgrade an application from Spark Classic to Spark?**
+
+No. However, we will continue to provide bug fixes and security updates to Spark Classic indefinitely.
+
+#### **Does Spark support any other payment providers?**
+
+No. Spark only supports Stripe and Paddle and it is not possible for developers to customize Spark to accept additional providers. If you need to use another payment provider **you should not purchase Laravel Spark**.
+
+#### **Am I required to use Tailwind / Blade / Vue / etc. in order to use Spark?**
+
+No. Spark's billing portal is totally isolated from the rest of your Laravel application and includes its own pre-compiled frontend assets. Your own application may be built using the frontend technologies of your choice.
+
+#### **Why are my customers presented with a payment confirmation screen?**
+
+Extra verification is sometimes required in order to confirm and process a payment. When this happens, Paddle or Stripe will present a payment confirmation screen. Payment confirmation screens presented by Paddle, Stripe, or Spark may be tailored to a specific bank or card issuer's payment flow and can include additional card confirmation, a temporary small charge, separate device authentication, or other forms of verification.

--- a/3.x/spark-paddle/README.md
+++ b/3.x/spark-paddle/README.md
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0;url=/docs/2.x/spark-paddle/configuration.html" />

--- a/3.x/spark-paddle/configuration.md
+++ b/3.x/spark-paddle/configuration.md
@@ -1,0 +1,212 @@
+# Configuration
+
+[[toc]]
+
+## Introduction
+
+In the following documentation, we will discuss how to configure a Laravel Spark installation when using the [Paddle](https://paddle.com) payment provider. All of Spark's configuration options are housed in your application's `config/spark.php` configuration file.
+
+## Paddle Configuration
+
+Of course, to use Paddle as a payment provider for your Laravel Spark application you must have an active [Paddle account](https://paddle.com). **While you are developing your application, you may use the [Paddle Sandbox](https://developer.paddle.com/getting-started/sandbox)**.
+
+### Environment Variables
+
+Next, you should configure the application environment variables that will be needed by Spark in order to access your Paddle account. These variables should be placed in your application's `.env` environment file.
+
+Of course, you should adjust the variable's values to correspond to your own Paddle account's credentials. In addition, you should set the `PADDLE_SANDBOX` variable to `true` if you are using Paddle's sandbox environment. Your Paddle API credentials and public key are available in your Paddle account dashboard via the "Developer Tools" section's "Authentication", "Public Key", and "SDK API" panels:
+
+```bash
+CASHIER_CURRENCY=USD
+CASHIER_CURRENCY_LOCALE=en
+PADDLE_SANDBOX=true
+PADDLE_VENDOR_ID=your-paddle-vendor-id
+PADDLE_VENDOR_AUTH_CODE=your-paddle-vendor-auth-code
+PADDLE_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
+MIICIjANBiuqhiiG9w0BAQEFXAOCAg8AMIIjjgKCAraAyj/UyC89sqpOnpEZcM76
+guppK9vfF7balLj87rE9VXq5...EAAQ==
+-----END PUBLIC KEY-----"
+```
+
+:::danger Configuring Locales
+
+In order to use locales other than `en`, ensure the `ext-intl` PHP extension is installed and configured on your server.
+:::
+
+### Paddle Webhooks
+
+In addition, your Spark powered application will need to receive webhooks from Paddle in order to keep your application's billing and subscription data in sync with Paddle's. Within your Paddle dashboard's "Alerts / Webhooks" management panel, you should configure Paddle to send webhook alerts to your application's `/spark/webhook` URI. You should enable webhook alerts for the following events:
+
+- Subscription Created
+- Subscription Updated
+- Subscription Cancelled
+- Subscription Payment Success
+- Subscription Payment Failed
+- High Risk Transaction Created
+- High Risk Transaction Updated
+
+#### Webhooks & Local Development
+
+For Paddle to be able to send your application webhooks during local development, you will need to expose your application via a site sharing service such as [Ngrok](https://ngrok.io) or [Expose](https://beyondco.de/docs/expose/introduction). If you are developing your application locally using [Laravel Sail](http://laravel.com/docs/sail), you may use Sail's [site sharing command](https://laravel.com/docs/sail#sharing-your-site).
+
+## Configuring Billables
+
+Spark allows you to define the types of billable models that your application will be managing. Most commonly, applications bill individual users for monthly and yearly subscription plans. However, your application may choose to bill some other type of model, such as a team, organization, band, etc.
+
+You may define your billable models within the `billables` array of your application's `spark` configuration file. By default, this array contains an entry for the `App\Models\User` model.
+
+Before continuing, you should ensure that the model class that corresponds to your billable model is using the `Spark\Billable` trait:
+
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Spark\Billable;
+
+class User extends Authenticatable
+{
+    use Billable, HasFactory, Notifiable;
+}
+```
+
+### Billable Slugs
+
+As you may have noticed, each entry in the `billables` configuration array is keyed by a "slug" that is a shortened form of the billable model class. This slug can be used when accessing the Spark customer billing portal, such as `https://example.com/billing/user` or `https://example.com/billing/team`.
+
+### Billable Resolution
+
+When you installed Laravel Spark, an `App\Providers\SparkServiceProvider` class was created for you. Within this service provider, you will find a callback that is used by Spark to resolve the billable model instance when accessing the Spark billing portal. By default, this callback simply returns the currently authenticated user, which is the desired behavior for most applications using Laravel Spark:
+
+```php
+use App\Models\User;
+use Illuminate\Http\Request;
+use Spark\Spark;
+
+Spark::billable(User::class)->resolve(function (Request $request) {
+    return $request->user();
+});
+```
+
+However, if your application is not billing individual users, you may need to adjust this callback. For example, if your application offers team billing instead of user billing, you might customize the callback like so:
+
+```php
+use App\Models\Team;
+use Illuminate\Http\Request;
+use Spark\Spark;
+
+Spark::billable(Team::class)->resolve(function (Request $request) {
+    return $request->user()->currentTeam;
+});
+```
+
+### Billable Authorization
+
+Next, let's examine the authorization callbacks that Spark will use to determine if the currently authenticated user of your application is authorized to view the billing portal for a particular billable model.
+
+When you installed Laravel Spark, an `App\Providers\SparkServiceProvider` class was created for you. Within this service provider, you will find the authorization callback definition used to determine if a given user is authorized to view the billing portal for the `App\Models\User` billable class. Of course, if your application is not billing users, you should update the billable class and authorization callback logic to fit your application's needs. By default, Spark will simply verify that the currently authenticated user can only manage its own billing settings:
+
+```php
+use App\Models\User;
+use Illuminate\Http\Request;
+use Spark\Spark;
+
+Spark::billable(User::class)->authorize(function (User $billable, Request $request) {
+    return $request->user() &&
+           $request->user()->id == $billable->id;
+});
+```
+
+If the authorization callback returns `true`, the currently authenticated user will be authorized to view the billing portal and manage the billing settings for the given `$billable` model. If the callback returns `false`, the request to access the billing portal will be denied.
+
+You are free to customize the `authorize` callback based on your own application's needs. For example, if your application bills teams instead of individual users, you might update the callback like so:
+
+```php
+use App\Models\Team;
+use Illuminate\Http\Request;
+use Spark\Spark;
+
+Spark::billable(Team::class)->authorize(function (Team $billable, Request $request) {
+    return $request->user() &&
+           $request->user()->ownsTeam($billable);
+});
+```
+
+### Billable Email Address
+
+By default, Spark will use your billable model's `email` attribute as the email address associated with the Paddle customer record it creates for the model. If you would like to specify another attribute that should be used instead, you may define a `paddleEmail` method on your billable model:
+
+```php
+/**
+ * Get the email address that should be associated with the Paddle customer.
+ *
+ * @return string
+ */
+public function paddleEmail()
+{
+    return $this->email;
+}
+```
+
+## Defining Subscription Plans
+
+As we previously discussed, Spark allows you to define the types of billable models that your application will be managing. These billable models are defined within the `billables` array of your application's `config/spark.php` configuration file:
+
+Each billable configuration within the `billables` array contains a `plans` array. Within this array you may configure each of the billing plans offered by your application to that particular billable type. **The `monthly_id` and `yearly_id` identifiers should correspond to the plan identifiers associated with the subscription plan within your Paddle account dashboard:**
+
+```php
+use App\Models\User;
+
+'billables' => [
+    'user' => [
+        'model' => User::class,
+        'trial_days' => 5,
+        'plans' => [
+            [
+                'name' => 'Standard',
+                'short_description' => 'This is a short, human friendly description of the plan.',
+                'monthly_id' => env('SPARK_STANDARD_MONTHLY_PLAN', 1000),
+                'yearly_id' => env('SPARK_STANDARD_YEARLY_PLAN', 1001),
+                'features' => [
+                    'Feature 1',
+                    'Feature 2',
+                    'Feature 3',
+                ],
+            ],
+        ],
+    ],
+]
+```
+
+If your subscription plan only offers a monthly billing cycle, you may omit the `yearly_id` identifier from your plan configuration. Likewise, if your plan only offers a yearly billing cycle, you may omit the `monthly_id` identifier.
+
+In addition, you are free to supply a short description of the plan and a list of features relevant to the plan. This information will be displayed in the Spark billing portal.
+
+## Accessing The Billing Portal
+
+Once you have configured your Spark installation, you may access your application's billing portal at the `/billing` URI. So, if your application is being served on `localhost`, you may access your application's billing portal at `http://localhost/billing`.
+
+Of course, you may link to the billing portal from your application's dashboard however you see fit:
+
+```html
+<a href="/billing">
+    Manage Subscription
+</a>
+```
+
+#### Billing Portal & Multiple Billables
+
+If your application is billing more than one type of billable, you should add the billable type's [slug](#billable-slugs) to the `/billing` URI. For example, if you have configured a `team` billable type in addition to your `user` billable type, you may access the billing portal for teams by navigating to `http://localhost/billing/team`. However, this typically should not be necessary because most applications will only ever bill one type of model.
+
+## Showing A Link To The Terms And Conditions
+
+Many applications display billing terms and conditions during checkout. Spark allows you to easily do the same within your application's billing portal. To get started, add a `terms_url` configuration value in your application's `config/spark.php` configuration file:
+
+```php
+'terms_url' => '/terms'
+```
+
+Once added, Spark will display a link pointing to `/terms` in the billing portal.

--- a/3.x/spark-paddle/cookbook.md
+++ b/3.x/spark-paddle/cookbook.md
@@ -1,0 +1,81 @@
+# Cookbook
+
+[[toc]]
+
+## Team Billing
+
+Spark ships with "user" based billing by default. If your applications bills teams or a different model instead, you will need to adjust your Spark installation accordingly. We'll walk through these adjustments in the following documentation using a team billing implementation as an example.
+
+To make the `App\Models\Team` model our billable model, we first need to adjust Spark's service provider.
+
+#### Updating The Service Provider
+
+Now we should update the `SparkServiceProvider` to reference the `Team` model instead of the `User` model:
+
+```php
+use App\Models\Team;
+use Spark\Spark;
+
+class SparkServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        // Resolve the current team...
+        Spark::billable(Team::class)->resolve(function (Request $request) {
+            return $request->user()->currentTeam;
+        });
+
+        // Verify that the current user owns the team...
+        Spark::billable(Team::class)->authorize(function (Team $billable, Request $request) {
+            return $request->user() &&
+                   $request->user()->id == $billable->user_id;
+        });
+
+        Spark::billable(Team::class)->checkPlanEligibility(function (Team $billable, Plan $plan) {
+            // ...
+        });
+    }
+}
+```
+
+#### Updating The Model
+
+Now we can update the `Team` model to use the `Spark\Billable` trait and implement a `paddleEmail` method that returns the team owner's email address to be displayed in the Paddle dashboard as the customer identifier:
+
+```php
+use Spark\Billable;
+
+class Team extends JetstreamTeam
+{
+    use Billable;
+
+    public function paddleEmail()
+    {
+        return $this->owner->email;
+    }
+}
+```
+
+
+#### Spark Configuration File
+
+Finally, update your application's `config/spark.php` configuration file so that it defines a `team` billable model:
+
+```php
+use App\Models\Team;
+
+'billables' => [
+    'team' => [
+        'model' => Team::class,
+
+        'plans' => [
+            // ...
+        ],
+    ],
+]
+```

--- a/3.x/spark-paddle/customization.md
+++ b/3.x/spark-paddle/customization.md
@@ -69,9 +69,9 @@ This command will publish a `resources/lang/spark/en.json` file containing trans
 
 ## Webhooks
 
-Spark and Cashier automatically handles subscription cancellation on failed charges and other common Paddle webhooks, but if you have additional webhook events you would like to handle, you may do so by listening to the `WebhookReceived` event from Cashier.
+Spark and Cashier automatically handle subscription cancellations for failed charges and other common Paddle webhook events. However, if you have additional webhook events you would like to handle, you may do so by listening to the `WebhookReceived` event that is dispatched by Cashier.
 
-First, you should create a listener for the event. Inside this listener's `handle` method you'll receive the `WebhookReceived` event which contains the event payload. The first thing you should do is check if the alert name is the one you want to act on:
+First, you should create a listener for the event. Then, inside of the listener's `handle` method, you will receive the `WebhookReceived` event which contains the event payload. You may inspect this event's payload to determine if the given listener should handle the underlying Paddle event:
 
 ```php
 <?php
@@ -96,7 +96,7 @@ class PaddleEventListener
 }
 ```
 
-Inside this listener you can perform whatever changes you need. Next, we'll need to make sure our app can listen to the incoming event and act upon it. Add it to the `App\Providers\EventServiceProvider` class:
+Next, the listener should be registered in your application's `App\Providers\EventServiceProvider` class:
 
 ```php
 use App\Listeners\PaddleEventListener;
@@ -115,5 +115,3 @@ class EventServiceProvider extends ServiceProvider
         ],
     ];
 ```
-
-Now, whener a webhook is received, it'll be propogated to the listener where you can handle it. Of course, you can add as many listeners as you like.

--- a/3.x/spark-paddle/customization.md
+++ b/3.x/spark-paddle/customization.md
@@ -1,0 +1,112 @@
+# Customization
+
+[[toc]]
+
+## Branding
+
+Although Spark's billing portal is intended to be an isolated part of your application that is entirely managed by Spark, you can make some small customizations to the branding logo and color used by Spark.
+
+### Brand Logo
+
+To customize the logo used at the top left of the Spark billing portal, you may specify a configuration value for the `brand.logo` configuration item within your application's `config/spark.php` configuration file. This configuration value should contain an absolute path to the SVG file of the logo you would like to use:
+
+```php
+'brand' => [
+    'logo' => realpath(__DIR__.'/../public/img/logo.svg'),
+],
+```
+
+:::tip SVG Sizing
+
+You may need to adjust the size and width of your SVG logo by modifying its width in the SVG file itself.
+:::
+
+### Brand Color
+
+To customize the color used as the background color of the button elements within the Spark billing portal, you may specify a value for the `brand.color` configuration item within your application's `config/spark.php` configuration file. This configuration value should be a valid hex code or correspond to a background color offered by the [Tailwind CSS framework](https://tailwindcss.com/docs/customizing-colors):
+
+```php
+'brand' => [
+    'color' => 'bg-indigo-600',
+
+    // Or...
+
+    'color' => '#c5b358',
+],
+```
+
+### Font
+
+To customize the font used by the Spark billing portal, you should export Spark's views using the `vendor:publish` Artisan command:
+
+```bash
+php artisan vendor:publish --tag=spark-views
+```
+
+Next, within the `resources/views/vendor/spark/app.blade.php` template, you may define your own `font-sans` CSS class at the bottom of the templates `head` section:
+
+```html
+<head>
+    <!-- ...... -->
+
+    <style>
+        .font-sans {
+            font-family: 'Your Custom Font';
+        }
+    </style>
+</head>
+```
+
+## Localization
+
+You may localize / translate all of the text within the Spark billing portal. To publish the Spark localization file, you may use the `vendor:publish` Artisan command:
+
+```bash
+php artisan vendor:publish --tag=spark-lang
+```
+
+This command will publish a `resources/lang/spark/en.json` file containing translation keys and values for the English language. You may copy this file and translate it to the language of your choice. For more information on how to use Laravel's translation features, please consult the [Laravel localization documentation](https://laravel.com/docs/localization#using-translation-strings-as-keys).
+
+## Webhooks
+
+Spark and Cashier automatically handles subscription cancellation on failed charges and other common Paddle webhooks, but if you have additional webhook events you would like to handle, you should extend Spark's `WebhookController`.
+
+Your controller's method names should correspond to Cashier's controller method conventions. Specifically, methods should be prefixed with `handle` and the "camel case" name of the webhook you wish to handle. For example, if you wish to handle the `payment_succeeded` webhook, you should add a `handlePaymentSucceeded` method to the controller:
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use Spark\Http\Controllers\WebhookController as SparkWebhookController;
+
+class WebhookController extends SparkWebhookController
+{
+    /**
+     * Handle the payment succeeded webhook.
+     *
+     * @param  array  $payload
+     * @return void
+     */
+    public function handlePaymentSucceeded($payload)
+    {
+        // Handle the event...
+    }
+}
+```
+
+Next, define a route to your webhook controller within your application's `routes/web.php` file. This will overwrite the default route registered by Spark's service provider:
+
+```php
+use App\Http\Controllers\WebhookController;
+
+Route::post('/spark/webhook', WebhookController::class);
+```
+
+Finally, since Paddle webhooks need to bypass Laravel's CSRF protection, be sure to list the URI as an exception in your application's `App\Http\Middleware\VerifyCsrfToken` middleware or list the route outside of the `web` middleware group:
+
+```php
+protected $except = [
+    'spark/webhook',
+];
+```

--- a/3.x/spark-paddle/events.md
+++ b/3.x/spark-paddle/events.md
@@ -1,0 +1,21 @@
+# Events
+
+[[toc]]
+
+Cashier dispatches several [events](https://laravel.com/docs/events) that you may intercept and handle based on your application's needs. We will describe each of these events below.
+
+## `Laravel\Paddle\Events\SubscriptionCreated`
+
+This event is dispatched when a subscription is created with a status of `trialing` or `active`.
+
+## `Laravel\Paddle\Events\SubscriptionUpdated`
+
+This event is dispatched when a subscription is changed. Possible changes include plan changes, quantity changes, pausing a subscription, or resuming a subscription.
+
+## `Laravel\Paddle\Events\SubscriptionCancelled`
+
+This event is dispatched when a subscription expires. This happens when a paused or cancelled subscription is no longer within its cancellation "grace period".
+
+### Grace Periods
+
+When a subscription is cancelled, Cashier will automatically set the subscription's `ends_at` column in your database. This column is used to know when the billable's `subscribed` method should begin returning `false`. For example, if a customer cancels a subscription on March 1st, but the subscription was not scheduled to end until March 5th, the `subscribed` method will continue to return `true` until March 5th. This is done because a user is typically allowed to continue using an application until the end of their billing cycle.

--- a/3.x/spark-paddle/middleware.md
+++ b/3.x/spark-paddle/middleware.md
@@ -1,0 +1,39 @@
+# Middleware
+
+[[toc]]
+
+When building a subscription based application, you will commonly need to restrict access to certain routes to users that have an active subscription. For example, you may not want to let a user create a project if they are not subscribed to a billing plan. For that reason, Spark provides a convenient subscription verification [middleware](https://laravel.com/docs/middleware) that you may register with your application.
+
+To get started, register Spark's subscription verification middleware in your HTTP kernel's `$routeMiddleware` array. Your application's HTTP kernel is typically located at `app/Http/Kernel.php`:
+
+```php
+use Spark\Http\Middleware\VerifyBillableIsSubscribed;
+
+protected $routeMiddleware = [
+    // ...
+    'subscribed' => VerifyBillableIsSubscribed::class
+];
+```
+
+Once the middleware has been registered, you may attach it to any of your application's route definitions:
+
+```php
+Route::post('/projects', [ProjectController::class, 'store'])
+        ->middleware(['auth', 'subscribed']);
+```
+
+If the user has an active subscription, the request will continue to execute normally. However, if the user does not have an active subscription, they will be redirected to your application's Spark billing portal. If the request is an XHR request, a response with a 402 HTTP status code will be returned to the client.
+
+:::tip Manually Inspecting Subscription States
+
+Of course, you may always manually inspect a billable model's subscription status using the [methods provided by Laravel Cashier](https://laravel.com/docs/cashier-paddle#checking-subscription-status), which can be especially useful for verifying that a user is subscribed to a particular plan.
+:::
+
+#### Multiple Billables
+
+If your application has more than one configured billable model, you may pass the [billable slug](./configuration.md#billable-slugs) to the middleware to instruct Spark which billable model configuration to use when verifying the subscription. However, this typically should not be necessary because most applications will only ever bill one type of model:
+
+```php
+Route::post('/projects', [ProjectController::class, 'store'])
+        ->middleware(['auth', 'subscribed:team']);
+```

--- a/3.x/spark-paddle/plans.md
+++ b/3.x/spark-paddle/plans.md
@@ -1,0 +1,177 @@
+# Plans
+
+[[toc]]
+
+## Defining Payment Plans
+
+**For more information on defining payment plans for your application, please consult the [plan configuration documentation](./configuration.md#defining-subscription-plans).**
+
+## Trial Periods
+
+By default, the plan configuration in your application's `config/spark.php` configuration file contains a `trial_days` option with a value of `5`. This configuration option determines the amount of time the user is allowed to use your application during their free trial period. You are free to modify this configuration value based on your application's needs.
+
+In practical terms, this configuration option simply determines when the `onTrial` method of the billable model will begin returning `false` instead of `true`:
+
+```php
+$user = Auth::user();
+
+if ($user->onTrial()) {
+    // The user is still within their trial period...
+}
+```
+
+:::danger Paddle Trials
+
+Because Paddle does not allow plan quantity changes during trial periods, the Paddle edition of Spark does not support requiring a credit card up front when beginning a trial. All trial periods are started without a credit card or payment method provided up front during the user's initial registration process.
+
+**Therefore, you may assign each subscription plan zero trial days when configuring subscription plans in your Paddle dashboard.**
+:::
+
+## Determining Plan Eligibility
+
+Sometimes, you may wish to place limitations on a particular billing plan. For example, a project management application might limit users on a particular billing plan to a maximum of 10 projects, while a higher priced plan might allow the creation of up to 20 projects.
+
+If you choose to take this approach to billing, you will need to instruct Spark how to determine if a given billable model is eligible to be placed on a particular billing plan. You may accomplish this by modifying the `checkPlanEligibility` callback registered within your application's `App\Providers\SparkServiceProvider` class. This callback will be invoked when a billable model attempts to subscribe to or switch to a new subscription plan:
+
+```php
+use App\Models\User;
+use Illuminate\Validation\ValidationException;
+use Spark\Plan;
+use Spark\Spark;
+
+Spark::billable(User::class)->checkPlanEligibility(function ($billable, Plan $plan) {
+    if (count($billable->projects) > 10 && $plan->name == 'Basic') {
+        throw ValidationException::withMessages([
+            'plan' => 'You have too many projects for the selected plan.'
+        ]);
+    }
+});
+```
+
+## Per-Seat Billing Plans
+
+Some applications charge users per "seat" instead of a fixed monthly price. For example, a project management application might charge $10 monthly **per project** such that if a user managed five projects they would be billed $50 monthly.
+
+If your application will be using per-seat billing, you will likely define a single, monthly plan in your application's `config/spark.php` configuration file. In addition, you will need to instruct Spark how to calculate the current number of "seats" a billable model is currently using.
+
+:::danger Enabling Plan Quantity
+
+While creating your subscription plans in Paddle's dashboard, make sure you select "Enable quantity". Otherwise, Paddle will ignore any quantity sent by Spark for per-seat billing.
+:::
+
+You may instruct Spark how to calculate the current number of "seats" a billable model is currently using via the `chargePerSeat` method when configuring a billable model. Typically, this method should be called within the `boot` method of your application's `App\Providers\SparkServiceProvider` class:
+
+```php
+use App\Models\User;
+use Spark\Spark;
+
+Spark::billable(User::class)->chargePerSeat('project', function ($billable) {
+    return $billable->projects()->count();
+});
+```
+
+The first argument accepted by the `chargePerSeat` method is the term that your application uses to refer to a "seat". In the case of a project management application, this would be a "project". The second argument given to the `chargePerSeat` method should be a closure that accepts the billable model and returns the current number of "seats" occupied by that model.
+
+After configuring per-seat billing, Spark will automatically update the wording within your application's billing portal to inform users that billing is calculated on a per-seat basis.
+
+### Incrementing / Decrementing The Seat Count
+
+The `chargePerSeat` callback that was explained above will inform Spark of the current seat count that should be used when a customer initiates a subscription. However, you still need to inform Spark when to add or remove a seat when a user is using your application. For example, if building a project management application that bills per project, you would need to inform Spark when a user creates or deletes a project. You can accomplish this by calling the `addSeat` and `removeSeat` method:
+
+```php
+$user->addSeat();
+
+$user->removeSeat();
+```
+
+Paddle does not allow subscription quantities below "1". Therefore, you should never decrease the seat count to zero. Instead, you may cancel the subscription plan.
+
+## Determining Subscription Status
+
+While building your application, you will often need to inspect a user's subscription status and plan to determine if they are allowed to perform a given action. For example, you may not want to let a user create a project if they are subscribed to a billing plan that only allows a specific number of projects to be created. First, you should review the [subscription verification middleware](./middleware.md) provided by Spark.
+
+Additionally, you may always manually inspect a billable model's subscription status using the [methods provided by Laravel Cashier](https://laravel.com/docs/cashier-paddle#checking-subscription-status), which can be especially useful for verifying that a user is subscribed to a particular plan:
+
+```php
+if ($user->subscribed()) {
+    // The user has an active subscription...
+}
+
+if ($user->subscribedToPlan($planId = 1000)) {
+    // The user has a subscription to a plan with a Paddle plan ID of 1000...
+}
+```
+
+## Defining Plan Incentive Text
+
+Spark allows you to define plan "incentive" text to display to your users. For example, you may wish to display the amount saved by choosing to use a yearly plan vs. a monthly plan. Incentive text is shown in the top right corner of the plan's card:
+
+![Incentive text example](./../../assets/img/incentive.png)
+
+To define incentive text, you may add `monthly_incentive` and / or `yearly_incentive` configuration options to your plan definition:
+
+```php
+[
+    'name' => 'Standard',
+    'short_description' => 'This is a short, human friendly description of the plan.',
+    'monthly_id' => env('SPARK_STANDARD_MONTHLY_PLAN', 1000),
+    'yearly_id' => env('SPARK_STANDARD_YEARLY_PLAN', 1001),
+    'yearly_incentive' => 'Save 10%',
+    'features' => [
+        'Feature 1',
+        'Feature 2',
+        'Feature 3',
+    ],
+],
+```
+
+## Access A Billable's Spark Plan
+
+Sometimes you may wish to access the Spark plan instance for a given billable in order to determine what options are available to the plan. For example, if your plan definition contains the following:
+
+```php
+[
+    'name' => 'Standard',
+    'short_description' => 'This is a short, human friendly description of the plan.',
+    'monthly_id' => env('SPARK_STANDARD_MONTHLY_PLAN', 1000),
+    'yearly_id' => env('SPARK_STANDARD_YEARLY_PLAN', 1001),
+    'features' => [
+        // ...
+    ],
+    'options' => [
+        'database_backups' => true,
+    ],
+],
+```
+
+You may access the plan and options like so:
+
+```php
+if ($user->sparkPlan()) {
+    $canCreateBackups = $user->sparkPlan()->options['database_backups'] ?? false;
+}
+```
+
+## Archiving Plans
+
+If you plan to "archive" or retire a particular plan for your application, you should add the `archived` configuration option to the plan's configuration array. You should not completely remove the plan's configuration if existing users of your application that have already subscribed to the plan will be allowed to continue their subscription:
+
+```php
+'plans' => [
+    [
+        'name' => 'Standard',
+        // ...
+        'archived' => true,
+    ],
+],
+```
+
+## Account Deletion
+
+If your application allows users to completely delete their account data, you should ensure that you cancel any subscription plans that the user has subscribed to before you delete their data. Otherwise, the user may continue to be billed even after you have deleted their data. You may cancel their subscription using [Laravel Cashier's](https://laravel.com/docs/cashier-paddle) typical subscription management methods. Depending on the billable types used by your application, you may need to adjust this code to your application's unique needs:
+
+```php
+if (optional($user->subscription())->recurring()) {
+    $user->subscription()->cancelNow();
+}
+```

--- a/3.x/spark-paddle/testing.md
+++ b/3.x/spark-paddle/testing.md
@@ -1,0 +1,43 @@
+# Testing
+
+[[toc]]
+
+## Factories
+
+While developing your application, you will likely want to "stub" a subscription record in your application's database so that calls to the `$billable->subscribed()` method return `true`.
+
+To accomplish this, you may add a "state" method to your billable model's [factory class](https://laravel.com/docs/database-testing#defining-model-factories). Typically, this will be your application's `UserFactory` class. Below you will find an example state method implementation; however, you are free to adjust this to your application's own needs:
+
+```php
+/**
+ * Indicate that the user should have a subscription plan.
+ *
+ * @param  int  $planId
+ * @return \Illuminate\Database\Eloquent\Factories\Factory
+ */
+public function withSubscription($planId = null)
+{
+    return $this->afterCreating(function ($user) use ($planId) {
+        optional($user->customer)->update(['trial_ends_at' => null]);
+
+        $user->subscriptions()->create([
+            'name' => 'default',
+            'paddle_id' => random_int(1, 1000),
+            'paddle_status' => 'active',
+            'paddle_plan' => $planId,
+            'quantity' => 1,
+            'trial_ends_at' => null,
+            'paused_from' => null,
+            'ends_at' => null,
+        ]);
+    });
+}
+```
+
+Once you have defined the state method, you may use it when creating models via your factory:
+
+```php
+$user = User::factory()->withSubscription($planId = 1000)->create();
+
+$user->subscribed(); // true
+```

--- a/3.x/spark-paddle/upgrade.md
+++ b/3.x/spark-paddle/upgrade.md
@@ -2,11 +2,11 @@
 
 [[toc]]
 
-## Upgrading to Spark (Paddle) 3.0 From v2.x
+## Upgrading to Spark (Paddle) 3.0 from 2.x
 
 ### Removed Events
 
-Spark Paddle's own events were removed in favor of Cashier Paddle's events. You can update them like so:
+Spark's own events were removed in favor of using Cashier's events directly. You should update any reference to these events to their Cashier equivalents:
 
 ```diff
 -Spark\Events\SubscriptionCreated

--- a/3.x/spark-paddle/upgrade.md
+++ b/3.x/spark-paddle/upgrade.md
@@ -1,0 +1,22 @@
+# Upgrade
+
+[[toc]]
+
+## Upgrading to Spark (Paddle) 2.0 From v1.x
+
+Spark (Paddle) 2.0 is a maintenance release with no breaking changes. To upgrade, simply update your application's `composer.json` file to depend on the latest release:
+
+```json
+"require": {
+    "php": "^8.0",
+    "laravel/framework": "^9.0",
+    "laravel/spark-paddle": "^2.0"
+},
+```
+
+### Minimum Versions
+
+The following required dependency versions have been updated:
+
+- The minimum Laravel version is now v9.0
+- The minimum PHP version is now v8.0

--- a/3.x/spark-paddle/upgrade.md
+++ b/3.x/spark-paddle/upgrade.md
@@ -2,21 +2,17 @@
 
 [[toc]]
 
-## Upgrading to Spark (Paddle) 2.0 From v1.x
+## Upgrading to Spark (Paddle) 3.0 From v2.x
 
-Spark (Paddle) 2.0 is a maintenance release with no breaking changes. To upgrade, simply update your application's `composer.json` file to depend on the latest release:
+### Removed Events
 
-```json
-"require": {
-    "php": "^8.0",
-    "laravel/framework": "^9.0",
-    "laravel/spark-paddle": "^2.0"
-},
+Spark Paddle's own events were removed in favor of Cashier Paddle's events. You can update them like so:
+
+```diff
+-Spark\Events\SubscriptionCreated
+-Spark\Events\SubscriptionUpdated
+-Spark\Events\SubscriptionDeleted
++Laravel\Cashier\Events\SubscriptionCreated
++Laravel\Cashier\Events\SubscriptionUpdated
++Laravel\Cashier\Events\SubscriptionDeleted
 ```
-
-### Minimum Versions
-
-The following required dependency versions have been updated:
-
-- The minimum Laravel version is now v9.0
-- The minimum PHP version is now v8.0

--- a/3.x/spark-stripe/README.md
+++ b/3.x/spark-stripe/README.md
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0;url=/docs/2.x/spark-paddle/configuration.html" />

--- a/3.x/spark-stripe/configuration.md
+++ b/3.x/spark-stripe/configuration.md
@@ -155,9 +155,9 @@ Spark::billable(Team::class)->authorize(function (Team $billable, Request $reque
 });
 ```
 
-### Syncing Customer Data
+### Syncing Customer Data With Stripe
 
-Spark will sync customer data like name, email and billing address. This means that every time this data changes Spark will peform a Stripe API request. To offload this, it's best that you [configure a queue](https://laravel.com/docs/queues). 
+Spark synchronizes user data such as name, email, and billing address information to Stripe when this data is updated on the underlying billable Eloquent model. To ensure that this does not negatively affect the performance of your application, we recommend that you configure a [queue worker](https://laravel.com/docs/queues). If a queue worker has been configured, Spark will automatically perform Stripe data synchronization using your application's default queue.
 
 ## Defining Subscription Plans
 

--- a/3.x/spark-stripe/configuration.md
+++ b/3.x/spark-stripe/configuration.md
@@ -1,0 +1,250 @@
+# Configuration
+
+[[toc]]
+
+## Introduction
+
+In the following documentation, we will discuss how to configure a Laravel Spark installation when using the [Stripe](https://stripe.com) payment provider. All of Spark's configuration options are housed in your application's `config/spark.php` configuration file.
+
+## Stripe Configuration
+
+Of course, to use Stripe as a payment provider for your Laravel Spark application you must have an active [Stripe account](https://stripe.com).
+
+### Environment Variables
+
+Next, you should configure the application environment variables that will be needed by Spark in order to access your Stripe account. These variables should be placed in your application's `.env` environment file.
+
+Of course, you should adjust the variable's values to correspond to your own Stripe account's credentials. Your Stripe API credentials and public key are available in your Stripe account dashboard:
+
+```bash
+CASHIER_CURRENCY=USD
+CASHIER_CURRENCY_LOCALE=en
+STRIPE_KEY=pk_test_example
+STRIPE_SECRET=sk_test_example
+STRIPE_WEBHOOK_SECRET=sk_test_example
+```
+
+:::danger Configuring Locales
+
+In order to use locales other than `en`, ensure the `ext-intl` PHP extension is installed and configured on your server.
+:::
+
+### Stripe Webhooks
+
+In addition, your Spark powered application will need to receive webhooks from Stripe in order to keep your application's billing and subscription data in sync with Stripe's. Within your Stripe dashboard's webhook management panel, you should configure Stripe to send webhook alerts to your application's `/spark/webhook` URI. You should enable webhook alerts for the following events:
+
+- customer.deleted
+- customer.subscription.created
+- customer.subscription.deleted
+- customer.subscription.updated
+- customer.updated
+- invoice.payment_action_required
+- invoice.payment_succeeded
+
+#### Webhooks & Local Development
+
+During local development, you will need a way for Stripe to send webhooks to your application running oun your local machine. An easy way to get started is via [the Stripe CLI](https://stripe.com/docs/stripe-cli), which provides a convenient `listen` command. For example, if you are developing locally via the `artisan serve` CLI command and serving your site at `http://localhost:8000`, you may run the following Stripe CLI command to allow Stripe to communicate with your application:
+
+```shell
+stripe listen --forward-to http://localhost:8000/spark/webhook
+```
+
+Alternatively, you can expose your application via another site sharing service such as [Ngrok](https://ngrok.io) or [Expose](https://beyondco.de/docs/expose/introduction). If you are developing your application locally using [Laravel Sail](http://laravel.com/docs/sail), you may use Sail's [site sharing command](https://laravel.com/docs/sail#sharing-your-site).
+
+## Configuring Billables
+
+Spark allows you to define the types of billable models that your application will be managing. Most commonly, applications bill individual users for monthly and yearly subscription plans. However, your application may choose to bill some other type of model, such as a team, organization, band, etc. The Stripe edition of Spark currently only supports a single billable model entity (team, user, etc.) per application.
+
+You may define your billable models within the `billables` array of your application's `spark` configuration file. By default, this array contains an entry for the `App\Models\User` model. If the billable model is something other than `App\Models\User`, you should invoke Cashier's `useCustomerModel` method in the `boot` method of your `SparkServiceProvider` class in order to inform Cashier of your custom model:
+
+```php
+use App\Entities\User;
+use Laravel\Cashier\Cashier;
+ 
+/**
+ * Bootstrap any application services.
+ *
+ * @return void
+ */
+public function boot()
+{
+    Cashier::useCustomerModel(User::class);
+}
+```
+
+Before continuing, you should ensure that the model class that corresponds to your billable model is using the `Spark\Billable` trait and that it casts the `trial_ends_at` attribute to `datetime`:
+
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Spark\Billable;
+
+class User extends Authenticatable
+{
+    use Billable, HasFactory, Notifiable;
+
+    protected $casts = [
+        'trial_ends_at' => 'datetime',
+    ];
+
+}
+```
+
+### Billable Slugs
+
+As you may have noticed, each entry in the `billables` configuration array is keyed by a "slug" that is a shortened form of the billable model class. This slug can be used when accessing the Spark customer billing portal, such as `https://example.com/billing/user` or `https://example.com/billing/team`.
+
+### Billable Resolution
+
+When you installed Laravel Spark, an `App\Providers\SparkServiceProvider` class was created for you. Within this service provider, you will find a callback that is used by Spark to resolve the billable model instance when accessing the Spark billing portal. By default, this callback simply returns the currently authenticated user, which is the desired behavior for most applications using Laravel Spark:
+
+```php
+use App\Models\User;
+use Illuminate\Http\Request;
+use Spark\Spark;
+
+Spark::billable(User::class)->resolve(function (Request $request) {
+    return $request->user();
+});
+```
+
+However, if your application is not billing individual users, you may need to adjust this callback. For example, if your application offers team billing instead of user billing, you might customize the callback like so:
+
+```php
+use App\Models\Team;
+use Illuminate\Http\Request;
+use Spark\Spark;
+
+Spark::billable(Team::class)->resolve(function (Request $request) {
+    return $request->user()->currentTeam;
+});
+```
+
+### Billable Authorization
+
+Next, let's examine the authorization callbacks that Spark will use to determine if the currently authenticated user of your application is authorized to view the billing portal for a particular billable model.
+
+When you installed Laravel Spark, an `App\Providers\SparkServiceProvider` class was created for you. Within this service provider, you will find the authorization callback definition used to determine if a given user is authorized to view the billing portal for the `App\Models\User` billable class. Of course, if your application is not billing users, you should update the billable class and authorization callback logic to fit your application's needs. By default, Spark will simply verify that the currently authenticated user can only manage its own billing settings:
+
+```php
+use App\Models\User;
+use Illuminate\Http\Request;
+use Spark\Spark;
+
+Spark::billable(User::class)->authorize(function (User $billable, Request $request) {
+    return $request->user() &&
+           $request->user()->id == $billable->id;
+});
+```
+
+If the authorization callback returns `true`, the currently authenticated user will be authorized to view the billing portal and manage the billing settings for the given `$billable` model. If the callback returns `false`, the request to access the billing portal will be denied.
+
+You are free to customize the `authorize` callback based on your own application's needs. For example, if your application bills teams instead of individual users, you might update the callback like so:
+
+```php
+use App\Models\Team;
+use Illuminate\Http\Request;
+use Spark\Spark;
+
+Spark::billable(Team::class)->authorize(function (Team $billable, Request $request) {
+    return $request->user() &&
+           $request->user()->ownsTeam($billable);
+});
+```
+
+## Defining Subscription Plans
+
+As we previously discussed, Spark allows you to define the types of billable models that your application will be managing. These billable models are defined within the `billables` array of your application's `config/spark.php` configuration file:
+
+Each billable configuration within the `billables` array contains a `plans` array. Within this array you may configure each of the billing plans offered by your application to that particular billable type. **The `monthly_id` and `yearly_id` identifiers should correspond to the price / plan identifiers configured within your Stripe account dashboard:**
+
+```php
+use App\Models\User;
+
+'billables' => [
+    'user' => [
+        'model' => User::class,
+        'trial_days' => 5,
+        'plans' => [
+            [
+                'name' => 'Standard',
+                'short_description' => 'This is a short, human friendly description of the plan.',
+                'monthly_id' => 'price_id',
+                'yearly_id' => 'price_id',
+                'features' => [
+                    'Feature 1',
+                    'Feature 2',
+                    'Feature 3',
+                ],
+            ],
+        ],
+    ],
+]
+```
+
+If your subscription plan only offers a monthly billing cycle, you may omit the `yearly_id` identifier from your plan configuration. Likewise, if your plan only offers a yearly billing cycle, you may omit the `monthly_id` identifier.
+
+In addition, you are free to supply a short description of the plan and a list of features relevant to the plan. This information will be displayed in the Spark billing portal.
+
+## Accessing The Billing Portal
+
+Once you have configured your Spark installation, you may access your application's billing portal at the `/billing` URI. So, if your application is being served on `localhost`, you may access your application's billing portal at `http://localhost/billing`.
+
+Of course, you may link to the billing portal from your application's dashboard however you see fit:
+
+```html
+<a href="/billing">
+    Manage Subscription
+</a>
+```
+
+## Showing A Link To The Terms And Conditions
+
+Many applications display billing terms and conditions during checkout. Spark allows you to easily do the same within your application's billing portal. To get started, add a `terms_url` configuration value in your application's `config/spark.php` configuration file:
+
+```php
+'terms_url' => '/terms'
+```
+
+Once added, Spark will display a link pointing to `/terms` in the billing portal.
+
+## Receipt Emails
+
+Spark Stripe can also email subscription payment receipts to your customers. To enable this feature, uncomment the 'receiptEmails' feature entry in your application's `config/spark.php` configuration file:
+
+```php
+'features' => [
+    // ...
+    Features::receiptEmails(),
+    // ...
+]
+```
+
+If you would like to grant your customers the ability to specify the email address that receipts should be sent to, you may provide the `custom-addresses` option to the feature definition:
+
+```php
+'features' => [
+    // ...
+    Features::receiptEmails(['custom-addresses' => true]),
+    // ...
+]
+```
+
+If you enable email receipts within your application, we suggest disabling [Stripe's receipt mailing](https://dashboard.stripe.com/settings/billing/automatic) feature so that customers do not receive duplicate receipt emails.
+
+## Failed Payment Emails
+
+Since SCA regulations require customers to occasionally verify their payment details even while their subscription is active, Spark can send a notification to the customer when off-session payment confirmation is required. Spark's payment confirmation notifications can be enabled by enabling the `paymentNotificationEmails` feature within your application's `config/spark.php` configuration file:
+
+```php
+'features' => [
+    // ...
+    Features::paymentNotificationEmails(),
+    // ...
+]
+```

--- a/3.x/spark-stripe/configuration.md
+++ b/3.x/spark-stripe/configuration.md
@@ -157,6 +157,10 @@ Spark::billable(Team::class)->authorize(function (Team $billable, Request $reque
 });
 ```
 
+### Syncing Customer Data
+
+Spark will sync customer data like name, email and billing address. This means that every time this data changes Spark will peform a Stripe API request. To offload this, it's best that you [configure a queue](https://laravel.com/docs/queues). 
+
 ## Defining Subscription Plans
 
 As we previously discussed, Spark allows you to define the types of billable models that your application will be managing. These billable models are defined within the `billables` array of your application's `config/spark.php` configuration file:

--- a/3.x/spark-stripe/cookbook.md
+++ b/3.x/spark-stripe/cookbook.md
@@ -1,0 +1,112 @@
+# Cookbook
+
+[[toc]]
+
+## Team Billing
+
+Spark ships with "user" based billing by default. If your applications bills teams or a different model instead, you will need to adjust your Spark installation accordingly. We'll walk through these adjustments in the following documentation using a team billing implementation as an example.
+
+To make the `App\Models\Team` model our billable model, we first need to adjust Spark's default migrations. So, let's configure Spark to ignore its own default migrations and export the migrations to our application so that we can adjust them:
+
+#### Customizing The Migrations
+
+To instruct Spark to ignore its migrations, call the `Spark::ignoreMigrations()` method in the `register` method of your application's `App\Providers\SparkServiceProvider` class:
+
+```php
+use Spark\Spark;
+
+public function register()
+{
+    Spark::ignoreMigrations();
+}
+```
+
+Next, execute the following Artisan command to publish the migrations:
+
+```bash
+php artisan vendor:publish --tag=spark-migrations
+```
+
+Now that the migrations are published in the `/database/migrations` directory, we need to change the name of the `2019_05_03_000001_add_spark_columns_to_users_table.php` file to `2020_05_03_000001_add_spark_columns_to_teams_table.php`. Adjusting the "year" of the migration will ensure the migration is run after the `teams` table is created in the database.
+
+After renaming the migration, you may update its contents such that it updates the table definition of the `teams` table instead of the `users` table. Also, update the first column so that it is added after a field on the `teams` table instead of `remember_token`.
+
+Next, update the `subscriptions` table migration to contain `team_id`instead of `user_id`. You should also ensure that you update the column in the migration's index as well.
+
+Finally, you also need to update the migration of the `receipts` table to use the `team_id` column instead of `user_id`.
+
+#### Updating The Service Provider
+
+Now that the migrations have been updated, we should update the `SparkServiceProvider` to reference the `Team` model instead of the `User` model:
+
+```php
+use App\Models\Team;
+use Laravel\Cashier\Cashier;
+use Spark\Spark;
+
+class SparkServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        // Instruct Cashier to use the `Team` model instead of the `User` model...
+        Cashier::useCustomerModel(Team::class);
+
+        // Resolve the current team...
+        Spark::billable(Team::class)->resolve(function (Request $request) {
+            return $request->user()->currentTeam;
+        });
+
+        // Verify that the current user owns the team...
+        Spark::billable(Team::class)->authorize(function (Team $billable, Request $request) {
+            return $request->user() &&
+                   $request->user()->id == $billable->user_id;
+        });
+
+        Spark::billable(Team::class)->checkPlanEligibility(function (Team $billable, Plan $plan) {
+            // ...
+        });
+    }
+}
+```
+
+#### Updating The Model
+
+Now we can update the `Team` model to use the `Spark\Billable` trait and implement a `stripeEmail` method that returns the team owner's email address to be displayed in the Stripe dashboard as the customer identifier:
+
+```php
+use Spark\Billable;
+
+class Team extends JetstreamTeam
+{
+    use Billable;
+
+    public function stripeEmail()
+    {
+        return $this->owner->email;
+    }
+}
+```
+
+
+#### Spark Configuration File
+
+Finally, update your application's `config/spark.php` configuration file so that it defines a `team` billable model:
+
+```php
+use App\Models\Team;
+
+'billables' => [
+    'team' => [
+        'model' => Team::class,
+
+        'plans' => [
+            // ...
+        ],
+    ],
+]
+```

--- a/3.x/spark-stripe/customization.md
+++ b/3.x/spark-stripe/customization.md
@@ -1,0 +1,150 @@
+# Customization
+
+[[toc]]
+
+## Branding
+
+Although Spark's billing portal is intended to be an isolated part of your application that is entirely managed by Spark, you can make some small customizations to the branding logo and color used by Spark.
+
+### Brand Logo
+
+To customize the logo used at the top left of the Spark billing portal, you may specify a configuration value for the `brand.logo` configuration item within your application's `config/spark.php` configuration file. This configuration value should contain an absolute path to the SVG file of the logo you would like to use:
+
+```php
+'brand' => [
+    'logo' => realpath(__DIR__.'/../public/img/logo.svg'),
+],
+```
+
+:::tip SVG Sizing
+
+You may need to adjust the size and width of your SVG logo by modifying its width in the SVG file itself.
+:::
+
+### Brand Color
+
+To customize the color used as the background color of the button elements within the Spark billing portal, you may specify a value for the `brand.color` configuration item within your application's `config/spark.php` configuration file. This configuration value should be a valid hex code or correspond to a background color offered by the [Tailwind CSS framework](https://tailwindcss.com/docs/customizing-colors):
+
+```php
+'brand' => [
+    'color' => 'bg-indigo-600',
+
+    // Or...
+
+    'color' => '#c5b358',
+],
+```
+
+### Font
+
+To customize the font used by the Spark billing portal, you should export Spark's views using the `vendor:publish` Artisan command:
+
+```bash
+php artisan vendor:publish --tag=spark-views
+```
+
+Next, within the `resources/views/vendor/spark/app.blade.php` template, you may define your own `font-sans` CSS class at the bottom of the templates `head` section:
+
+```html
+<head>
+    <!-- ...... -->
+
+    <style>
+        .font-sans {
+            font-family: 'Your Custom Font';
+        }
+    </style>
+</head>
+```
+
+## Localization
+
+You may localize / translate all of the text within the Spark billing portal. To publish the Spark localization file, you may use the `vendor:publish` Artisan command:
+
+```bash
+php artisan vendor:publish --tag=spark-lang
+```
+
+This command will publish a `resources/lang/spark/en.json` file containing translation keys and values for the English language. You may copy this file and translate it to the language of your choice. For more information on how to use Laravel's translation features, please consult the [Laravel localization documentation](https://laravel.com/docs/localization#using-translation-strings-as-keys).
+
+## Migrations
+
+Most commonly, applications bill individual users for monthly and yearly subscription plans. However, your application may choose to bill some other type of model, such as a team, organization, band, etc.
+
+In that case, you should add `Spark::ignoreMigrations()` in the `register` method of your application's `App\Providers\SparkServiceProvider` class:
+
+```php
+use Spark\Spark;
+
+class SparkServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        Spark::ignoreMigrations();
+
+        // ...
+    }
+}
+```
+
+Next, you should publish the Spark migrations by running the `vendor:publish` Artisan command:
+
+```bash
+php artisan vendor:publish --tag="spark-migrations"
+```
+
+Finally, you should inspect the published migrations and update the `2019_05_03_000001_add_spark_columns_to_users_table.php` file to add the columns needed by Spark to the table that will be used by your application's billable model.
+
+## Webhooks
+
+Spark and Cashier automatically handle subscription cancellations for failed charges and other common Stripe webhook events. However, if you have additional webhook events you would like to handle, you may do so by extending the Spark webhook controller.
+
+Your controller's method names should correspond to Cashier's controller conventions. Specifically, methods should be prefixed with `handle` and the "camel case" name of the webhook you wish to handle. For example, if you wish to handle the `invoice.payment_succeeded` webhook, you should add a `handleInvoicePaymentSucceeded` method to the controller:
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use Spark\Http\Controllers\WebhookController as SparkWebhookController;
+
+class WebhookController extends SparkWebhookController
+{
+    /**
+     * Handle invoice payment succeeded.
+     *
+     * @param  array  $payload
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function handleInvoicePaymentSucceeded($payload)
+    {
+        // Handle the incoming event...
+
+        return parent::handleInvoicePaymentSucceeded($payload);
+    }
+}
+```
+
+Next, define a route to your webhook controller within your application's `routes/web.php` file. This will overwrite the default route registered by Spark's service provider:
+
+```php
+use App\Http\Controllers\WebhookController;
+
+Route::post(
+    '/spark/webhook',
+    [WebhookController::class, 'handleWebhook']
+);
+```
+
+Finally, since Stripe webhooks need to bypass Laravel's CSRF protection, be sure to list the URI as an exception in your application's `App\Http\Middleware\VerifyCsrfToken` middleware or list the route outside of the `web` middleware group:
+
+```php
+protected $except = [
+    'spark/webhook',
+];
+```

--- a/3.x/spark-stripe/customization.md
+++ b/3.x/spark-stripe/customization.md
@@ -100,9 +100,9 @@ Finally, you should inspect the published migrations and update the `2019_05_03_
 
 ## Webhooks
 
-Spark and Cashier automatically handle subscription cancellations for failed charges and other common Stripe webhook events. However, if you have additional webhook events you would like to handle, you may do so by listening to the `WebhookReceived` event from Cashier.
+Spark and Cashier automatically handle subscription cancellations for failed charges and other common Stripe webhook events. However, if you have additional webhook events you would like to handle, you may do so by listening to the `WebhookReceived` event that is dispatched by Cashier.
 
-First, you should create a listener for the event. Inside this listener's `handle` method you'll receive the `WebhookReceived` event which contains the event payload. The first thing you should do is check if the event type is the one you want to act on:
+First, you should create a listener for the event. Then, inside of the listener's `handle` method, you will receive the `WebhookReceived` event which contains the event payload. You may inspect this event's payload to determine if the given listener should handle the underlying Stripe event:
 
 ```php
 <?php
@@ -127,7 +127,7 @@ class StripeEventListener
 }
 ```
 
-Inside this listener you can perform whatever changes you need. Next, we'll need to make sure our app can listen to the incoming event and act upon it. Add it to the `App\Providers\EventServiceProvider` class:
+Next, the listener should be registered in your application's `App\Providers\EventServiceProvider` class:
 
 ```php
 use App\Listeners\StripeEventListener;
@@ -146,5 +146,3 @@ class EventServiceProvider extends ServiceProvider
         ],
     ];
 ```
-
-Now, whener a webhook is received, it'll be propogated to the listener where you can handle it. Of course, you can add as many listeners as you like.

--- a/3.x/spark-stripe/customization.md
+++ b/3.x/spark-stripe/customization.md
@@ -111,7 +111,6 @@ First, you should create a listener for the event. Inside this listener's `handl
 
 namespace App\Listeners;
 
-use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Events\WebhookReceived;
 
 class StripeEventListener

--- a/3.x/spark-stripe/events.md
+++ b/3.x/spark-stripe/events.md
@@ -2,7 +2,7 @@
 
 [[toc]]
 
-Spark dispatches several [events](https://laravel.com/docs/events) that you may intercept and handle based on your application's needs. We will describe each of these events below. Each event contains a `$billable` instance and a `$subscription` instance.
+Spark dispatches several [events](https://laravel.com/docs/events) that you may intercept and handle based on your application's needs. We will describe each of these events below. Each event defines a `$billable` instance and a `$subscription` instance as public properties available for your application.
 
 ## `Spark\Events\SubscriptionCreated`
 

--- a/3.x/spark-stripe/events.md
+++ b/3.x/spark-stripe/events.md
@@ -1,0 +1,25 @@
+# Events
+
+[[toc]]
+
+Spark dispatches several [events](https://laravel.com/docs/events) that you may intercept and handle based on your application's needs. We will describe each of these events below.
+
+## `Spark\Events\SubscriptionCreated`
+
+This event is dispatched when a subscription is created with a status of `trialing` or `active`.
+
+## `Spark\Events\SubscriptionUpdated`
+
+This event is dispatched when a subscription is changed. Possible changes include plan changes, quantity changes, pausing a subscription, or resuming a subscription.
+
+## `Spark\Events\SubscriptionCancelled`
+
+This event is dispatched when a subscription expires. This happens when a paused or cancelled subscription is no longer within its cancellation "grace period".
+
+## `Spark\Events\PaymentSucceeded`
+
+This event is dispatched when a new Stripe invoice is created.
+
+### Grace Periods
+
+When a subscription is cancelled, Cashier will automatically set the subscription's `ends_at` column in your database. This column is used to know when the billable's `subscribed` method should begin returning `false`. For example, if a customer cancels a subscription on March 1st, but the subscription was not scheduled to end until March 5th, the `subscribed` method will continue to return `true` until March 5th. This is done because a user is typically allowed to continue using an application until the end of their billing cycle.

--- a/3.x/spark-stripe/events.md
+++ b/3.x/spark-stripe/events.md
@@ -2,7 +2,7 @@
 
 [[toc]]
 
-Spark dispatches several [events](https://laravel.com/docs/events) that you may intercept and handle based on your application's needs. We will describe each of these events below.
+Spark dispatches several [events](https://laravel.com/docs/events) that you may intercept and handle based on your application's needs. We will describe each of these events below. Each event contains a `$billable` instance and a `$subscription` instance.
 
 ## `Spark\Events\SubscriptionCreated`
 

--- a/3.x/spark-stripe/middleware.md
+++ b/3.x/spark-stripe/middleware.md
@@ -1,0 +1,30 @@
+# Middleware
+
+[[toc]]
+
+When building a subscription based application, you will commonly need to restrict access to certain routes to users that have an active subscription. For example, you may not want to let a user create a project if they are not subscribed to a billing plan. For that reason, Spark provides a convenient subscription verification [middleware](https://laravel.com/docs/middleware) that you may register with your application.
+
+To get started, register Spark's subscription verification middleware in your HTTP kernel's `$routeMiddleware` array. Your application's HTTP kernel is typically located at `app/Http/Kernel.php`:
+
+```php
+use Spark\Http\Middleware\VerifyBillableIsSubscribed;
+
+protected $routeMiddleware = [
+    // ...
+    'subscribed' => VerifyBillableIsSubscribed::class
+];
+```
+
+Once the middleware has been registered, you may attach it to any of your application's route definitions:
+
+```php
+Route::post('/projects', [ProjectController::class, 'store'])
+        ->middleware(['auth', 'subscribed']);
+```
+
+If the user has an active subscription, the request will continue to execute normally. However, if the user does not have an active subscription, they will be redirected to your application's Spark billing portal. If the request is an XHR request, a response with a 402 HTTP status code will be returned to the client.
+
+:::tip Manually Inspecting Subscription States
+
+Of course, you may always manually inspect a billable model's subscription status using the [methods provided by Laravel Cashier](https://laravel.com/docs/billing#checking-subscription-status), which can be especially useful for verifying that a user is subscribed to a particular plan.
+:::

--- a/3.x/spark-stripe/plans.md
+++ b/3.x/spark-stripe/plans.md
@@ -1,0 +1,211 @@
+# Plans
+
+[[toc]]
+
+## Defining Payment Plans
+
+**For more information on defining payment plans for your application, please consult the [plan configuration documentation](./configuration.md#defining-subscription-plans).**
+
+## Trial Periods
+
+By default, the plan configuration in your application's `config/spark.php` configuration file contains a `trial_days` option with a value of `5`. This configuration option determines the amount of time the user is allowed to use your application during their free trial period. You are free to modify this configuration value based on your application's needs.
+
+In practical terms, this configuration option simply determines when the `onTrial` method of the billable model will begin returning `false` instead of `true`:
+
+```php
+$user = Auth::user();
+
+if ($user->onTrial()) {
+    // The user is still within their trial period...
+}
+```
+
+### Requiring A Payment Method Up Front
+
+Some applications may need to require a payment method up front before beginning a free trial. The Stripe edition of Spark supports this behavior. To get started, you will add a `trial_days` configuration option to the individual plan configuration array and remove the `trial_days` configuration option that is within the billable configuration array:
+
+```php
+'user' => [
+    'model' => User::class,
+    // 'trial_days' => 5, Remove this configuration option...
+    'plans' => [
+        [
+            'name' => 'Standard',
+            'short_description' => 'This is a short, human friendly description of the plan.',
+            'trial_days' => 5,
+            // ...
+        ],
+    ],
+],
+```
+
+Now, after a billable model's initial registration, the `trialDays` method provided by the model instance will return `false`. You may examine the results of the `subscribed` method to conditionally show an alert to your user that they should select a subscription plan before beginning to use your application. For example, if you are using the Blade templating language:
+
+```html
+@if (! Auth::user()->subscribed())
+    <div>
+        You must <a href="/billing">select a subscription plan</a> before continuing.
+    </div>
+@endif
+```
+
+## Determining Plan Eligibility
+
+Sometimes, you may wish to place limitations on a particular billing plan. For example, a project management application might limit users on a particular billing plan to a maximum of 10 projects, while a higher priced plan might allow the creation of up to 20 projects.
+
+If you choose to take this approach to billing, you will need to instruct Spark how to determine if a given billable model is eligible to be placed on a particular billing plan. You may accomplish this by modifying the `checkPlanEligibility` callback registered within your application's `App\Providers\SparkServiceProvider` class. This callback will be invoked when a billable model attempts to subscribe to or switch to a new subscription plan:
+
+```php
+use App\Models\User;
+use Illuminate\Validation\ValidationException;
+use Spark\Plan;
+use Spark\Spark;
+
+Spark::billable(User::class)->checkPlanEligibility(function ($billable, Plan $plan) {
+    if (count($billable->projects) > 10 && $plan->name == 'Basic') {
+        throw ValidationException::withMessages([
+            'plan' => 'You have too many projects for the selected plan.'
+        ]);
+    }
+});
+```
+
+## Per-Seat Billing Plans
+
+Some applications charge users per "seat" instead of a fixed monthly price. For example, a project management application might charge $10 monthly **per project** such that if a user managed five projects they would be billed $50 monthly.
+
+If your application will be using per-seat billing, you will likely define a single, monthly plan in your application's `config/spark.php` configuration file. In addition, you will need to instruct Spark how to calculate the current number of "seats" a billable model is currently using.
+
+You may instruct Spark how to calculate the current number of "seats" a billable model is currently using via the `chargePerSeat` method when configuring a billable model. Typically, this method should be called within the `boot` method of your application's `App\Providers\SparkServiceProvider` class:
+
+```php
+use App\Models\User;
+use Spark\Spark;
+
+Spark::billable(User::class)->chargePerSeat('project', function ($billable) {
+    return $billable->projects()->count();
+});
+```
+
+The first argument accepted by the `chargePerSeat` method is the term that your application uses to refer to a "seat". In the case of a project management application, this would be a "project". The second argument given to the `chargePerSeat` method should be a closure that accepts the billable model and returns the current number of "seats" occupied by that model.
+
+After configuring per-seat billing, Spark will automatically update the wording within your application's billing portal to inform users that billing is calculated on a per-seat basis.
+
+### Incrementing / Decrementing The Seat Count
+
+The `chargePerSeat` callback that was explained above will inform Spark of the current seat count that should be used when a customer initiates a subscription. However, you still need to inform Spark when to add or remove a seat when a user is using your application. For example, if building a project management application that bills per project, you would need to inform Spark when a user creates or deletes a project. You can accomplish this by calling the `addSeat` and `removeSeat` method:
+
+```php
+$user->addSeat();
+
+$user->removeSeat();
+```
+
+Sometimes, payments for increasing seats can fail because a bank might require extra confirmation checks for card payments. When this happens, you should catch the `IncompletePayment` exception that occurs and handle it by redirecting to Cashier's payment page, while providing a `redirect` location back to the page that triggered the `addSeat` call:
+
+```php
+<?php
+
+use Laravel\Cashier\Exceptions\IncompletePayment;
+ 
+try {
+    $user->addSeat();
+} catch (IncompletePayment $exception) {
+    return redirect()->route(
+        'cashier.payment',
+        [$exception->payment->id, 'redirect' => route('spark.portal')]
+    );
+}
+```
+
+Please consult the [Cashier documentation](https://laravel.com/docs/billing#handling-failed-payments) for more information on handling failed payments.
+
+## Determining Subscription Status
+
+While building your application, you will often need to inspect a user's subscription status and plan to determine if they are allowed to perform a given action. For example, you may not want to let a user create a project if they are subscribed to a billing plan that only allows a specific number of projects to be created. First, you should review the [subscription verification middleware](./middleware.md) provided by Spark.
+
+Additionally, you may always manually inspect a billable model's subscription status using the [methods provided by Laravel Cashier](https://laravel.com/docs/billing#checking-subscription-status), which can be especially useful for verifying that a user is subscribed to a particular plan:
+
+```php
+if ($user->subscribed()) {
+    // The user has an active subscription...
+}
+
+if ($user->subscribedToPrice($planId = 'price_id')) {
+    // The user has a subscription to a plan with a Stripe plan / price ID of "price_id"...
+}
+```
+
+## Defining Plan Incentive Text
+
+Spark allows you to define plan "incentive" text to display to your users. For example, you may wish to display the amount saved by choosing to use a yearly plan vs. a monthly plan. Incentive text is shown in the top right corner of the plan's card:
+
+![Incentive text example](./../../assets/img/incentive.png)
+
+To define incentive text, you may add `monthly_incentive` and / or `yearly_incentive` configuration options to your plan definition:
+
+```php
+[
+    'name' => 'Standard',
+    'short_description' => 'This is a short, human friendly description of the plan.',
+    'monthly_id' => 'price_id',
+    'yearly_id' => 'price_id',
+    'yearly_incentive' => 'Save 10%',
+    'features' => [
+        'Feature 1',
+        'Feature 2',
+        'Feature 3',
+    ],
+],
+```
+
+## Access A Billable's Spark Plan
+
+Sometimes you may wish to access the Spark plan instance for a given billable in order to determine what options are available to the plan. For example, if your plan definition contains the following:
+
+```php
+[
+    'name' => 'Standard',
+    'short_description' => 'This is a short, human friendly description of the plan.',
+    'monthly_id' => 'price_id',
+    'yearly_id' => 'price_id',
+    'features' => [
+        // ...
+    ],
+    'options' => [
+        'database_backups' => true,
+    ],
+],
+```
+
+You may access the plan and options like so:
+
+```php
+if ($user->sparkPlan()) {
+    $canCreateBackups = $user->sparkPlan()->options['database_backups'] ?? false;
+}
+```
+
+## Archiving Plans
+
+If you plan to "archive" or retire a particular plan for your application, you should add the `archived` configuration option to the plan's configuration array. You should not completely remove the plan's configuration if existing users of your application that have already subscribed to the plan will be allowed to continue their subscription:
+
+```php
+'plans' => [
+    [
+        'name' => 'Standard',
+        // ...
+        'archived' => true,
+    ],
+],
+```
+
+## Account Deletion
+
+If your application allows users to completely delete their account data, you should ensure that you cancel any subscription plans that the user has subscribed to before you delete their data. Otherwise, the user may continue to be billed even after you have deleted their data. You may cancel their subscription using [Laravel Cashier's](https://laravel.com/docs/billing) typical subscription management methods. Depending on the billable types used by your application, you may need to adjust this code to your application's unique needs:
+
+```php
+if (optional($user->subscription())->recurring()) {
+    $user->subscription()->cancelNow();
+}
+```

--- a/3.x/spark-stripe/taxes.md
+++ b/3.x/spark-stripe/taxes.md
@@ -1,0 +1,15 @@
+# Taxes
+
+Spark may be configured to calculate and apply European Union VAT tax to subscriptions.
+
+To get started, you should uncomment the `Features::euVatCollection()` line within your application's `config/spark.php` configuration file. The value provided for the `home-country` option should be the two-character country code corresponding to the country where your business is located:
+
+```php
+use Spark\Features;
+
+'features' => [
+    Features::euVatCollection(['home-country' => 'BE']),
+],
+```
+
+Once you have completed these steps, Spark will automatically gather customer billing address information as well as VAT Number and apply the correct VAT based on the customer's location.

--- a/3.x/spark-stripe/testing.md
+++ b/3.x/spark-stripe/testing.md
@@ -1,0 +1,47 @@
+# Testing
+
+[[toc]]
+
+## Factories
+
+While developing your application, you will likely want to "stub" a subscription record in your application's database so that calls to the `$billable->subscribed()` method return `true`.
+
+To accomplish this, you may add a "state" method to your billable model's [factory class](https://laravel.com/docs/database-testing#defining-model-factories). Typically, this will be your application's `UserFactory` class. Below you will find an example state method implementation; however, you are free to adjust this to your application's own needs:
+
+```php
+/**
+ * Indicate that the user should have a subscription plan.
+ *
+ * @param  string  $planId
+ * @return \Illuminate\Database\Eloquent\Factories\Factory
+ */
+public function withSubscription($planId = null)
+{
+    return $this->afterCreating(function ($user) use ($planId) {
+        $subscription = $user->subscriptions()->create([
+            'name' => 'default',
+            'stripe_id' => Str::random(10),
+            'stripe_status' => 'active',
+            'stripe_price' => $planId,
+            'quantity' => 1,
+            'trial_ends_at' => null,
+            'ends_at' => null,
+        ]);
+
+        $subscription->items()->create([
+            'stripe_id' => Str::random(10),
+            'stripe_product' => Str::random(10),
+            'stripe_price' => $planId,
+            'quantity' => 1,
+        ]);
+    });
+}
+```
+
+Once you have defined the state method, you may use it when creating models via your factory:
+
+```php
+$user = User::factory()->withSubscription('price_id')->create();
+
+$user->subscribed(); // true
+```

--- a/3.x/spark-stripe/upgrade.md
+++ b/3.x/spark-stripe/upgrade.md
@@ -72,4 +72,4 @@ public function shouldSyncCustomerDetailsToStripe(): bool
 
 ### Removed Contracts
 
-Because the setup of new payment methods now happens via Stripe Checkout, the `Spark\Contracts\Actions\UpdatesBillingMethod` and its implementing class was removed.
+Because the setup of new payment methods now happens via Stripe Checkout, the `Spark\Contracts\Actions\UpdatesBillingMethod` contract and its implementing class was removed.

--- a/3.x/spark-stripe/upgrade.md
+++ b/3.x/spark-stripe/upgrade.md
@@ -1,0 +1,77 @@
+# Upgrade
+
+[[toc]]
+
+## Upgrading to Spark (Stripe) 3.0 From 2.x
+
+Spark (Stripe) 3.0 primarily provides an upgrade from Cashier 13.x to Cashier 14.x. As such, in addition to the upgrade guide below, please consult the [Cashier 14 upgrade guide](https://github.com/laravel/cashier-stripe/blob/14.x/UPGRADE.md).
+
+### Stripe API Version
+
+The default Stripe API version for Cashier 14.x is `2022-11-15`.
+
+If you use the Stripe SDK directly, make sure to properly test your integration after updating.
+
+#### Upgrading Your Stripe Webhook
+
+:::danger Deployment & Webhooks
+
+It's very important that you upgrade your webhook immediately after updating and deploying Spark in order to minimize conflicts where the API version of your webhook does not match the version used by Cashier.
+:::
+
+You should ensure your Stripe webhook operates on the same API version as Spark's underlying API version used by Cashier. To do so, you may use the `cashier:webhook` command from your production environment to create a new webhook that matches Cashier's Stripe API version. Of course, you should ensure the webhook's URL corresponds to the URL where your application expects to receive webhook requests. By default, your application will receive Spark Stripe webhooks at `/spark/webhook`:
+
+```bash
+php artisan cashier:webhook --disabled --url "https://your-site.com/spark/webhook"
+```
+
+This will create a new webhook with the same Stripe API version as Cashier [in your Stripe dashboard](https://dashboard.stripe.com/webhooks). The webhook will be immediately disabled so it doesn't interfere with your existing production application until you are ready to enable it.
+
+You may use the following upgrade checklist to properly enable to the new webhook:
+
+1. If you have webhook signature verification enabled, disable it on production by temporarily removing the `STRIPE_WEBHOOK_SECRET` environment variable.
+2. Add any extra Stripe events your application requires to the new webhook in your Stripe dashboard.
+3. Disable the old webhook in your Stripe dashboard.
+4. Enable the new webhook in your Stripe dashboard.
+5. Re-enable the new webhook secret by re-adding the `STRIPE_WEBHOOK_SECRET` environment variable in production with the secret from the new webhook.
+6. Remove the old webhook in your Stripe dashboard.
+
+After following this process, your new webhook will be active and ready to receive events.
+
+### Removing Top Ups
+
+Spark Stripe 3.0 removes all functionality related to top-ups. We've found that Stripe did not handle top-ups in a sufficient way needed to handle recurring subscription payments. Therefor it seemed better to remove this feature entirely. You should remove all related top-up functionality:
+
+```diff
+'features' => [
+    ...
+-   // Features::topUps(['price' => env('SPARK_TOP_UP_PRICE')]),
+    ...
+],
+```
+
+### Stripe Checkout Screens
+
+Spark Stripe 3.0 introduces Stripe Checkout for subscribing customers to new subscriptions and for adding new payment methods. These screens will provide a different experience to your customers than before. You can customize how Checkout looks by adjusting [your branding settings](https://dashboard.stripe.com/settings/branding).
+
+### Syncing Customer Details
+
+Spark Stripe 3.0 will now automatically sync your customer's details to Stripe. This includes their name, email address, billing address. This sync will be invoked whenever an update happens for your billable model. To more perfomantely sync these changes you should opt to [set up a queue](https://laravel.com/docs/queues). 
+
+If you don't want this sync to happen then you can add a `shouldSyncCustomerDetailsToStripe` method to your billable model:
+
+```php
+/**
+ * Determine if any Stripe synced customer data has changed.
+ *
+ * @return bool
+ */
+public function shouldSyncCustomerDetailsToStripe()
+{
+    return false;
+}
+```
+
+### Removed Contracts
+
+Because the setup of new payment methods now happens through Stripe Checkout, the `Spark\Contracts\Actions\UpdatesBillingMethod` and its implementing class was removed.

--- a/3.x/spark-stripe/upgrade.md
+++ b/3.x/spark-stripe/upgrade.md
@@ -2,7 +2,7 @@
 
 [[toc]]
 
-## Upgrading to Spark (Stripe) 3.0 From 2.x
+## Upgrading to Spark (Stripe) 3.0 from 2.x
 
 Spark (Stripe) 3.0 primarily provides an upgrade from Cashier 13.x to Cashier 14.x. As such, in addition to the upgrade guide below, please consult the [Cashier 14 upgrade guide](https://github.com/laravel/cashier-stripe/blob/14.x/UPGRADE.md).
 
@@ -25,7 +25,7 @@ You should ensure your Stripe webhook operates on the same API version as Spark'
 php artisan cashier:webhook --disabled --url "https://your-site.com/spark/webhook"
 ```
 
-This will create a new webhook with the same Stripe API version as Cashier [in your Stripe dashboard](https://dashboard.stripe.com/webhooks). The webhook will be immediately disabled so it doesn't interfere with your existing production application until you are ready to enable it.
+This command will create a new webhook with the same Stripe API version as Cashier [in your Stripe dashboard](https://dashboard.stripe.com/webhooks). The webhook will be immediately disabled so it doesn't interfere with your existing production application until you are ready to enable it.
 
 You may use the following upgrade checklist to properly enable to the new webhook:
 
@@ -33,14 +33,14 @@ You may use the following upgrade checklist to properly enable to the new webhoo
 2. Add any extra Stripe events your application requires to the new webhook in your Stripe dashboard.
 3. Disable the old webhook in your Stripe dashboard.
 4. Enable the new webhook in your Stripe dashboard.
-5. Re-enable the new webhook secret by re-adding the `STRIPE_WEBHOOK_SECRET` environment variable in production with the secret from the new webhook.
+5. Re-enable the new webhook secret verification by re-adding the `STRIPE_WEBHOOK_SECRET` environment variable in production with the secret from the new webhook.
 6. Remove the old webhook in your Stripe dashboard.
 
 After following this process, your new webhook will be active and ready to receive events.
 
-### Removing Top Ups
+### Removing Top-Ups
 
-Spark Stripe 3.0 removes all functionality related to top-ups. We've found that Stripe did not handle top-ups in a sufficient way needed to handle recurring subscription payments. Therefor it seemed better to remove this feature entirely. You should remove all related top-up functionality:
+Spark Stripe 3.0 removes all functionality related to top-ups. We've found that Stripe did not offer the functionality needed to fully utilize top-ups for recurring subscription payments. You should therefore remove the `topUps` feature from your Spark configuration file:
 
 ```diff
 'features' => [
@@ -52,13 +52,13 @@ Spark Stripe 3.0 removes all functionality related to top-ups. We've found that 
 
 ### Stripe Checkout Screens
 
-Spark Stripe 3.0 introduces Stripe Checkout for subscribing customers to new subscriptions and for adding new payment methods. These screens will provide a different experience to your customers than before. You can customize how Checkout looks by adjusting [your branding settings](https://dashboard.stripe.com/settings/branding).
+Spark Stripe 3.0 utilizes Stripe Checkout for finalizing subscriptions and adding new payment methods. You can customize the appearance of Stripe Checkout by adjusting [your branding settings within Stripe](https://dashboard.stripe.com/settings/branding).
 
 ### Syncing Customer Details
 
-Spark Stripe 3.0 will now automatically sync your customer's details to Stripe. This includes their name, email address, billing address. This sync will be invoked whenever an update happens for your billable model. To more perfomantely sync these changes you should opt to [set up a queue](https://laravel.com/docs/queues). 
+Spark Stripe 3.0 will now automatically sync some customer information to Stripe, including their name, email address, and billing address. This synchronization will only take place whenever an update to the relevant data occurs on your billable model. To ensure that this does not negatively affect the performance of your application, we should you [configure a Laravel queue worker](https://laravel.com/docs/queues), which Spark will automatically utilize to efficiently synchronize customer data to Stripe.
 
-If you don't want this sync to happen then you can add a `shouldSyncCustomerDetailsToStripe` method to your billable model:
+If you would like to disable customer data synchronization, you can define a `shouldSyncCustomerDetailsToStripe` method on your application's billable model:
 
 ```php
 /**
@@ -72,4 +72,4 @@ public function shouldSyncCustomerDetailsToStripe(): bool
 
 ### Removed Contracts
 
-Because the setup of new payment methods now happens through Stripe Checkout, the `Spark\Contracts\Actions\UpdatesBillingMethod` and its implementing class was removed.
+Because the setup of new payment methods now happens via Stripe Checkout, the `Spark\Contracts\Actions\UpdatesBillingMethod` and its implementing class was removed.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0;url=/docs/2.x/introduction.html" />
+<meta http-equiv="refresh" content="0;url=/docs/3.x/introduction.html" />


### PR DESCRIPTION
I've first copied the docs in the first commit, then added separate commits for all the changes I did so it's more easy to review. Only exception is the Spark Stripe v3 upgrade guide which I accidentally added to the first commit (but it's one file).

Please note that merging this will make these the default docs.