### PR TITLE
[3.x] Adds types to `v3` documentation

### DIFF
--- a/3.x/spark-paddle/configuration.md
+++ b/3.x/spark-paddle/configuration.md
@@ -142,10 +142,8 @@ By default, Spark will use your billable model's `email` attribute as the email 
 ```php
 /**
  * Get the email address that should be associated with the Paddle customer.
- *
- * @return string
  */
-public function paddleEmail()
+public function paddleEmail(): string|null
 {
     return $this->email;
 }

--- a/3.x/spark-paddle/cookbook.md
+++ b/3.x/spark-paddle/cookbook.md
@@ -20,10 +20,8 @@ class SparkServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap any application services.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         // Resolve the current team...
         Spark::billable(Team::class)->resolve(function (Request $request) {
@@ -54,7 +52,7 @@ class Team extends JetstreamTeam
 {
     use Billable;
 
-    public function paddleEmail()
+    public function paddleEmail(): string|null
     {
         return $this->owner->email;
     }

--- a/3.x/spark-paddle/customization.md
+++ b/3.x/spark-paddle/customization.md
@@ -84,11 +84,8 @@ class PaddleEventListener
 {
     /**
      * Handle the event.
-     *
-     * @param  \Laravel\Paddle\Events\WebhookReceived  $event
-     * @return void
      */
-    public function handle(WebhookReceived $event)
+    public function handle(WebhookReceived $event): void
     {
         if ($event->payload['alert_name'] === 'payment_succeeded') {
             return;

--- a/3.x/spark-paddle/testing.md
+++ b/3.x/spark-paddle/testing.md
@@ -9,15 +9,16 @@ While developing your application, you will likely want to "stub" a subscription
 To accomplish this, you may add a "state" method to your billable model's [factory class](https://laravel.com/docs/database-testing#defining-model-factories). Typically, this will be your application's `UserFactory` class. Below you will find an example state method implementation; however, you are free to adjust this to your application's own needs:
 
 ```php
+use App\Models\User;
+
 /**
  * Indicate that the user should have a subscription plan.
  *
- * @param  int  $planId
- * @return \Illuminate\Database\Eloquent\Factories\Factory
+ * @return $this
  */
-public function withSubscription($planId = null)
+public function withSubscription(string|int $planId = null): static
 {
-    return $this->afterCreating(function ($user) use ($planId) {
+    return $this->afterCreating(function (User $user) use ($planId) {
         optional($user->customer)->update(['trial_ends_at' => null]);
 
         $user->subscriptions()->create([

--- a/3.x/spark-stripe/configuration.md
+++ b/3.x/spark-stripe/configuration.md
@@ -63,10 +63,8 @@ use Laravel\Cashier\Cashier;
  
 /**
  * Bootstrap any application services.
- *
- * @return void
  */
-public function boot()
+public function boot(): void
 {
     Cashier::useCustomerModel(User::class);
 }

--- a/3.x/spark-stripe/cookbook.md
+++ b/3.x/spark-stripe/cookbook.md
@@ -15,7 +15,7 @@ To instruct Spark to ignore its migrations, call the `Spark::ignoreMigrations()`
 ```php
 use Spark\Spark;
 
-public function register()
+public function register(): void
 {
     Spark::ignoreMigrations();
 }
@@ -48,10 +48,8 @@ class SparkServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap any application services.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         // Instruct Cashier to use the `Team` model instead of the `User` model...
         Cashier::useCustomerModel(Team::class);
@@ -85,7 +83,7 @@ class Team extends JetstreamTeam
 {
     use Billable;
 
-    public function stripeEmail()
+    public function stripeEmail(): string|null
     {
         return $this->owner->email;
     }

--- a/3.x/spark-stripe/customization.md
+++ b/3.x/spark-stripe/customization.md
@@ -80,10 +80,8 @@ class SparkServiceProvider extends ServiceProvider
 {
     /**
      * Register any application services.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         Spark::ignoreMigrations();
 
@@ -117,11 +115,8 @@ class StripeEventListener
 {
     /**
      * Handle the event.
-     *
-     * @param  \Laravel\Cashier\Events\WebhookReceived  $event
-     * @return void
      */
-    public function handle(WebhookReceived $event)
+    public function handle(WebhookReceived $event): void
     {
         if ($event->payload['type'] !== 'customer.subscription.updated') {
             return;

--- a/3.x/spark-stripe/testing.md
+++ b/3.x/spark-stripe/testing.md
@@ -9,15 +9,16 @@ While developing your application, you will likely want to "stub" a subscription
 To accomplish this, you may add a "state" method to your billable model's [factory class](https://laravel.com/docs/database-testing#defining-model-factories). Typically, this will be your application's `UserFactory` class. Below you will find an example state method implementation; however, you are free to adjust this to your application's own needs:
 
 ```php
+use App\Models\User;
+
 /**
  * Indicate that the user should have a subscription plan.
  *
- * @param  string  $planId
- * @return \Illuminate\Database\Eloquent\Factories\Factory
+ * @return $this
  */
-public function withSubscription($planId = null)
+public function withSubscription(string|int $planId = null): static
 {
-    return $this->afterCreating(function ($user) use ($planId) {
+    return $this->afterCreating(function (User $user) use ($planId) {
         $subscription = $user->subscriptions()->create([
             'name' => 'default',
             'stripe_id' => Str::random(10),

--- a/3.x/spark-stripe/upgrade.md
+++ b/3.x/spark-stripe/upgrade.md
@@ -63,10 +63,8 @@ If you don't want this sync to happen then you can add a `shouldSyncCustomerDeta
 ```php
 /**
  * Determine if any Stripe synced customer data has changed.
- *
- * @return bool
  */
-public function shouldSyncCustomerDetailsToStripe()
+public function shouldSyncCustomerDetailsToStripe(): bool
 {
     return false;
 }


### PR DESCRIPTION
@driesvints This pull request - as discussed - adds types to the v3 documentation of Spark. Note, there is a few cases where they are the closure `$billable` was not clear to me regarding the type (if User, or anything else). You can search them by this match: `function ($billable`.