### PR TITLE
Explicitly highlight setting up webhooks

### DIFF
--- a/3.x/installation.md
+++ b/3.x/installation.md
@@ -9,6 +9,11 @@
 Before installing Spark, you will need to purchase a [Spark license](https://spark.laravel.com/licenses). You can purchase a Spark license via the Spark dashboard.
 :::
 
+:::danger Setting up Webhooks
+
+Please do not forget to set up webhooks when using Spark (both locally and in production). Consult the documentation below after installing Spark.
+:::
+
 To get started installing Spark, add the Spark repository to your application's `composer.json` file:
 
 ```json


### PR DESCRIPTION
We keep on getting support tickets from people who forget to set up their webhooks when working with Spark. I honestly don't know what else to do other than to have a big fat message on top of the install docs...