### PR TITLE
Update spark factory state example for paddle_id

### DIFF
--- a/4.x/spark-paddle/testing.md
+++ b/4.x/spark-paddle/testing.md
@@ -23,7 +23,7 @@ public function withSubscription(string|int $planId = null): static
 
         $user->subscriptions()->create([
             'name' => 'default',
-            'paddle_id' => $this->faker->unique()->numberBetween(1, 1000),
+            'paddle_id' => fake()->unique()->numberBetween(1, 1000),
             'paddle_status' => 'active',
             'paddle_plan' => $planId,
             'quantity' => 1,

--- a/4.x/spark-paddle/testing.md
+++ b/4.x/spark-paddle/testing.md
@@ -23,7 +23,7 @@ public function withSubscription(string|int $planId = null): static
 
         $user->subscriptions()->create([
             'name' => 'default',
-            'paddle_id' => random_int(1, 1000),
+            'paddle_id' => $this->faker->unique()->numberBetween(1, 1000),
             'paddle_status' => 'active',
             'paddle_plan' => $planId,
             'quantity' => 1,


### PR DESCRIPTION
If you grab the old snippet example and add it to a UserFactory, there is a chance to show a duplicate value and break the migrations, it should avoid this at least for 1,000 users and is an example easy to override if you need more subscriptions.