### PR TITLE
Document adding trials for existing users

### DIFF
--- a/src/spark-paddle/plans.md
+++ b/src/spark-paddle/plans.md
@@ -27,6 +27,24 @@ Because Paddle does not allow plan quantity changes during trial periods, the Pa
 **Therefore, you may assign each subscription plan zero trial days when configuring subscription plans in your Paddle dashboard.**
 :::
 
+### Trials For Existing Users
+
+When you install Spark into existing applications, existing users won't get their trial periods automatically. Therefor, you should assign these yourself when you deploy Spark to your app:
+
+```php
+use App\Models\User;
+
+User::all()->each(function (User $user) {
+    $trialDays = $user->sparkConfiguration('trial_days');
+
+    $user->createAsCustomer([
+        'trial_ends_at' => $trialDays ? now()->addDays($trialDays) : null,
+    ]);
+});
+```
+
+This will create a customer record for each user and grant them the trial period you have configured for this billable.
+
 ## Determining Plan Eligibility
 
 Sometimes, you may wish to place limitations on a particular billing plan. For example, a project management application might limit users on a particular billing plan to a maximum of 10 projects, while a higher priced plan might allow the creation of up to 20 projects.

--- a/src/spark-stripe/plans.md
+++ b/src/spark-stripe/plans.md
@@ -20,6 +20,24 @@ if ($user->onTrial()) {
 }
 ```
 
+### Trials For Existing Users
+
+When you install Spark into existing applications, existing users won't get their trial periods automatically. Therefor, you should assign these yourself when you deploy Spark to your app:
+
+```php
+use App\Models\User;
+
+User::all()->each(function (User $user) {
+    $trialDays = $user->sparkConfiguration('trial_days');
+
+    $user->forceFill([
+        'trial_ends_at' => $trialDays ? now()->addDays($trialDays) : null,
+    ])->save();
+});
+```
+
+This will update each user and grant them the trial period you have configured for this billable.
+
 ### Requiring A Payment Method Up Front
 
 Some applications may need to require a payment method up front before beginning a free trial. The Stripe edition of Spark supports this behavior. To get started, you will add a `trial_days` configuration option to the individual plan configuration array and remove the `trial_days` configuration option that is within the billable configuration array:


### PR DESCRIPTION
Resend of #36 now that we have new docs.

This documents adding trial periods for existing users when installing Spark into existing apps.