### PR TITLE
Make sure correct path is used for webhooks

### DIFF
--- a/src/spark-stripe/configuration.md
+++ b/src/spark-stripe/configuration.md
@@ -45,7 +45,7 @@ In addition, your Spark powered application will need to receive webhooks from S
 Or, when you're ready for production, you can create this webhook with all the necessary events by running the following command on your production server:
 
 ```bash
-php artisan cashier:webhook
+php artisan cashier:webhook --url="https://your-production-url.com/spark/webhook"
 ```
 
 After creation, the webhook will be active immediately. 


### PR DESCRIPTION
This changes should make it clear that the correct production url needs to be used when setting up webhooks in production.