### PR TITLE
Clarify exclude tax in prices

### DIFF
--- a/src/spark-stripe/taxes.md
+++ b/src/spark-stripe/taxes.md
@@ -2,6 +2,12 @@
 
 Spark may be configured to calculate and apply European Union VAT tax to subscriptions.
 
+:::tip Price Settings
+
+When creating prices in Stripe, make sure to **disable** "Include tax in price" so the proper tax rates can be added by Spark.
+:::
+
+
 To get started, you should uncomment the `Features::euVatCollection()` line within your application's `config/spark.php` configuration file. The value provided for the `home-country` option should be the two-character country code corresponding to the country where your business is located:
 
 ```php

--- a/src/spark-stripe/taxes.md
+++ b/src/spark-stripe/taxes.md
@@ -4,9 +4,8 @@ Spark may be configured to calculate and apply European Union VAT tax to subscri
 
 :::tip Price Settings
 
-When creating prices in Stripe, make sure to **disable** "Include tax in price" so the proper tax rates can be added by Spark.
+When creating prices in Stripe, you should **disable** the "Include tax in price" option so the proper tax rates can be added by Spark.
 :::
-
 
 To get started, you should uncomment the `Features::euVatCollection()` line within your application's `config/spark.php` configuration file. The value provided for the `home-country` option should be the two-character country code corresponding to the country where your business is located:
 


### PR DESCRIPTION
This should hopefully make it clear that Spark doesn't supports the "included tax" option. It needs prices to exclude tax to properly apply tax rates.