### PR TITLE
Fix incorrect explanation for SubscriptionCreated event

### DIFF
--- a/src/spark-stripe/events.md
+++ b/src/spark-stripe/events.md
@@ -6,7 +6,7 @@ Spark dispatches several [events](https://laravel.com/docs/events) that you may 
 
 ## `Spark\Events\SubscriptionCreated`
 
-This event is dispatched when a subscription is created with a status of `trialing` or `active`.
+This event is dispatched when a subscription becomes `active`.
 
 ## `Spark\Events\SubscriptionUpdated`
 


### PR DESCRIPTION
Apparently this description is wrong and this event is only fired when the subscription becomes active.

See https://secure.helpscout.net/conversation/2450514897/92144