### PR TITLE
Clarify unique Paddle email

### DIFF
--- a/src/spark-paddle/configuration.md
+++ b/src/spark-paddle/configuration.md
@@ -151,13 +151,18 @@ public function paddleName(): string|null
 }
 
 /**
- * Get the email address that should be associated with the Paddle customer.
+ * Get the unique email address that should be associated with the Paddle customer.
  */
 public function paddleEmail(): string|null
 {
     return $this->email;
 }
 ```
+
+::: warning Paddle Customer Email Address
+
+Please note that every email address on every billable needs to be unique. It is not possible within Paddle to associate multiple billables with the same email address.
+:::
 
 ## Defining Subscription Plans
 

--- a/src/spark-paddle/configuration.md
+++ b/src/spark-paddle/configuration.md
@@ -161,7 +161,7 @@ public function paddleEmail(): string|null
 
 ::: warning Paddle Customer Email Address
 
-Please note that every email address on every billable needs to be unique. It is not possible within Paddle to associate multiple billables with the same email address.
+Paddle requires each customer to have a unique email address, so multiple customers cannot share the same email.
 :::
 
 ## Defining Subscription Plans

--- a/src/spark-paddle/cookbook.md
+++ b/src/spark-paddle/cookbook.md
@@ -43,7 +43,7 @@ class SparkServiceProvider extends ServiceProvider
 
 #### Updating the Model
 
-Now we can update the `Team` model to use the `Spark\Billable` trait and implement a `paddleEmail` method that returns the team owner's email address to be displayed in the Paddle dashboard as the customer identifier:
+Now we can update the `Team` model to use the `Spark\Billable` trait and implement a `paddleEmail` method that returns the team owner's unique email address to be displayed in the Paddle dashboard as the customer identifier:
 
 ```php
 use Spark\Billable;
@@ -58,6 +58,8 @@ class Team extends JetstreamTeam
     }
 }
 ```
+
+This email address cannot be used on a different team then because of Paddle limitations. Ideally, you'd setup a custom `billing_email` column on the Team to have a dedicated and unique email address per team.
 
 #### Spark Configuration File
 

--- a/src/spark-paddle/cookbook.md
+++ b/src/spark-paddle/cookbook.md
@@ -59,7 +59,7 @@ class Team extends JetstreamTeam
 }
 ```
 
-This email address cannot be used on a different team then because of Paddle limitations. Ideally, you'd setup a custom `billing_email` column on the Team to have a dedicated and unique email address per team.
+Paddle requires each billable entity to have a unique email address, so multiple customers or teams cannot share the same email.
 
 #### Spark Configuration File
 


### PR DESCRIPTION
Attempt at clarifying that email addresses in Paddle need to be unique.