### PR TITLE
Update broken links node

### DIFF
--- a/.github/workflows/mintlify-broken-links.yml
+++ b/.github/workflows/mintlify-broken-links.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 'lts/*'
       
       - name: Install Mintlify
         run: npm i -g mintlify@latest

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -28,27 +28,3 @@ Spark's Paddle support is provided by the underlying [Laravel Cashier Paddle](ht
 [Stripe](https://stripe.com) is a global leader in payment infrastructure with direct integration with card networks and banks, a fast-improving platform, and battle-tested reliability. In addition, intelligent optimizations help increase revenue across conversion, prevent fraud, and assist with revenue recovery. Finally, Stripe provides a robust sandbox environment for you to test your application's payment system.
 
 Spark's Stripe support is provided by the underlying [Laravel Cashier Stripe](https://laravel.com/docs/billing) library.
-
-## Frequently Asked Questions
-
-<AccordionGroup>
-    <Accordion title="Is it possible to upgrade an application from Spark Classic to Spark?">
-        No. However, we will continue to provide bug fixes and security updates to Spark Classic indefinitely.
-    </Accordion>
-
-    <Accordion title="Can I sell Spark powered applications?">
-        You may not sell Spark powered applications on code distribution platforms such as Code Canyon, etc. However, if you build a SaaS application / business which is later acquired by a private third-party, you may transfer your Spark license to that buyer.
-    </Accordion>
-
-    <Accordion title="Does Spark support any other payment providers?">
-        No. Spark only supports Stripe and Paddle and it is not possible for developers to customize Spark to accept additional providers. If you need to use another payment provider **you should not purchase Laravel Spark**.
-    </Accordion>
-
-    <Accordion title="Am I required to use Tailwind / Blade / Vue / etc. in order to use Spark?">
-        No. Spark's billing portal is totally isolated from the rest of your Laravel application and includes its own pre-compiled frontend assets. Your own application may be built using the frontend technologies of your choice.
-    </Accordion>
-
-    <Accordion title="Why are my customers presented with a payment confirmation screen?">
-        Extra verification is sometimes required in order to confirm and process a payment. When this happens, Paddle or Stripe will present a payment confirmation screen. Payment confirmation screens presented by Paddle, Stripe, or Spark may be tailored to a specific bank or card issuer's payment flow and can include additional card confirmation, a temporary small charge, separate device authentication, or other forms of verification.
-    </Accordion>
-</AccordionGroup>

--- a/kb/faq.mdx
+++ b/kb/faq.mdx
@@ -1,0 +1,24 @@
+---
+title: 'Frequently Asked Questions'
+description: 'Frequently asked questions about Nova.'
+---
+
+## Is it possible to upgrade an application from Spark Classic to Spark?
+No. However, we will continue to provide bug fixes and security updates to Spark Classic indefinitely.
+
+
+## Can I sell Spark powered applications?
+You may not sell Spark powered applications on code distribution platforms such as Code Canyon, etc. However, if you build a SaaS application / business which is later acquired by a private third-party, you may transfer your Spark license to that buyer.
+
+
+## Does Spark support any other payment providers?
+No. Spark only supports Stripe and Paddle and it is not possible for developers to customize Spark to accept additional providers. If you need to use another payment provider **you should not purchase Laravel Spark**.
+
+
+## Am I required to use Tailwind / Blade / Vue / etc. in order to use Spark?
+No. Spark's billing portal is totally isolated from the rest of your Laravel application and includes its own pre-compiled frontend assets. Your own application may be built using the frontend technologies of your choice.
+
+
+## Why are my customers presented with a payment confirmation screen?
+Extra verification is sometimes required in order to confirm and process a payment. When this happens, Paddle or Stripe will present a payment confirmation screen. Payment confirmation screens presented by Paddle, Stripe, or Spark may be tailored to a specific bank or card issuer's payment flow and can include additional card confirmation, a temporary small charge, separate device authentication, or other forms of verification.
+    

--- a/mint.json
+++ b/mint.json
@@ -49,6 +49,16 @@
       "url": "https://blog.laravel.com/spark"
     }
   ],
+  "tabs": [
+    {
+      "name": "Documentation",
+      "url": "/"
+    },
+    {
+      "name": "Knowledge Base",
+      "url": "kb"
+    }
+  ],
   "navigation": [
     {
       "group": "Get Started",
@@ -83,6 +93,12 @@
         "spark-stripe/cookbook",
         "spark-stripe/customization",
         "spark-stripe/upgrade"
+      ]
+    },
+    {
+      "group": "Knowledge Base",
+      "pages": [
+        "kb/faq"
       ]
     }
   ],


### PR DESCRIPTION
- Mintlify [updated their node prerequisite from 18 to 19](https://mintlify.com/docs/development).
- Setting it to use the latest LTS version
-  Updating `actions/setup-node` to v4
-  Updating `actions/checkout` to v4