### PR TITLE
Updating broken links GH workflow node version

### DIFF
--- a/.github/workflows/mintlify-broken-links.yml
+++ b/.github/workflows/mintlify-broken-links.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 'lts/*'
       
       - name: Install Mintlify
         run: npm i -g mintlify@latest


### PR DESCRIPTION
- Mintlify [updated their node prerequisite from 18 to 19](https://mintlify.com/docs/development).
- Setting it to use the latest LTS version
-  Updating `actions/setup-node` to v4
-  Updating `actions/checkout` to v4