### PR TITLE
Table Deprecation receipts

### DIFF
--- a/spark-stripe/upgrade.mdx
+++ b/spark-stripe/upgrade.mdx
@@ -39,6 +39,10 @@ You may use the following upgrade checklist to properly enable to the new webhoo
 
 After following this process, your new webhook will be active and ready to receive events.
 
+### Table Deprecation
+
+While the `receipts` table contains historical data that may be valuable for reference, it is no longer used and can be safely removed.
+
 ### Publishing Migrations
 
 Spark Stripe 5.0 no longer automatically loads migrations from its own migrations directory. Instead, you should run the following command to publish Spark's migrations to your application:

--- a/spark-stripe/upgrade.mdx
+++ b/spark-stripe/upgrade.mdx
@@ -39,10 +39,6 @@ You may use the following upgrade checklist to properly enable to the new webhoo
 
 After following this process, your new webhook will be active and ready to receive events.
 
-### Table Deprecation
-
-While the `receipts` table contains historical data that may be valuable for reference, it is no longer used and can be safely removed.
-
 ### Publishing Migrations
 
 Spark Stripe 5.0 no longer automatically loads migrations from its own migrations directory. Instead, you should run the following command to publish Spark's migrations to your application:
@@ -50,6 +46,10 @@ Spark Stripe 5.0 no longer automatically loads migrations from its own migration
 ```bash
 php artisan vendor:publish --tag=spark-migrations
 ```
+
+### Receipts Table Deprecation
+
+While the `receipts` table contains historical data that may be valuable for reference, it is no longer used and can be safely removed.
 
 ### Receipts Renamed to Invoices
 


### PR DESCRIPTION
Documenting the deprecation of the receipts table on the spark stripe upgrade guide.