### PR TITLE
Fix small typo in cookbook.mdx

### DIFF
--- a/spark-stripe/cookbook.mdx
+++ b/spark-stripe/cookbook.mdx
@@ -5,7 +5,7 @@ description: 'Learn how to configure your Spark Stripe application.'
 
 ## Team Billing
 
-Spark ships with "user" based billing by default. If your applications bills teams or a different model instead, you will need to adjust your Spark installation accordingly. We'll walk through these adjustments in the following documentation using a team billing implementation as an example.
+Spark ships with "user" based billing by default. If your application bills teams or a different model instead, you will need to adjust your Spark installation accordingly. We'll walk through these adjustments in the following documentation using a team billing implementation as an example.
 
 To make the `App\Models\Team` model your billable model, you first need to adjust Spark's default migrations:
 


### PR DESCRIPTION
Fixes a small typo in cookboox.mdx "applications" -> "application".