### PR TITLE
Adjusting Blog Link

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -46,7 +46,7 @@
     {
       "name": "Blog",
       "icon": "newspaper",
-      "url": "https://blog.laravel.com/spark"
+      "url": "https://blog.laravel.com"
     }
   ],
   "tabs": [


### PR DESCRIPTION
Current one throws 404.
I'm using the same as Forge, which is blog.laravel.com