### PR TITLE
Upgrade guide for Spark (Stripe) 6.0 and 5.0

### DIFF
--- a/spark-stripe/upgrade.mdx
+++ b/spark-stripe/upgrade.mdx
@@ -3,6 +3,34 @@ title: 'Upgrade'
 description: 'Learn how to upgrade your Spark Stripe application.'
 ---
 
+## Upgrading to Spark (Stripe) 6.0 From 4.x
+
+Spark (Stripe) 6.0 primarily provides an upgrade from Cashier 15.x to Cashier 16.x. As such, in addition to the upgrade guide below, please consult the [Cashier 16 upgrade guide](https://github.com/laravel/cashier-stripe/blob/16.x/UPGRADE.md).
+
+
+### Stripe API Version
+
+The default Stripe API version for Cashier 16 is `2025-07-30.basil`. If this is the latest Stripe API version when you upgrade to this Cashier version, then we recommend you also upgrade your Stripe API version settings in your Stripe dashboard to this version after deploying the Cashier upgrade. If this is no longer the latest Stripe API version, we recommend you do not modify your Stripe API version settings.
+
+Older Stripe accounts (e.g., those created before Basil previews) may encounter compatibility issues with Basil billing APIs or require manual API key upgrades in the Stripe dashboard. We recommend testing in a staging environment, as some legacy features might not migrate seamlessly. Note that `StripeApiVersion::CURRENT` is used internally, so the exact version could evolve with minor Cashier releases — lock your dashboard version post-upgrade to avoid drift.
+
+If you use the Stripe SDK directly, make sure to properly test your integration after updating.
+
+### Database Migration Changes
+
+
+To better track usage-based billings, we've added `meter_event_name` and `meter_id` to the `subscription_items` table. The `meter_id` column is `nullable` and is cast as a string in the model.
+
+If you have custom queries or indexes on `subscription_items`, consider adding them for these fields. Additionally, internal ID generation has changed from `uniqid()` to `Str::uuid()`, which is unlikely to affect user code but could impact extensions relying on prefix-based uniqueness.
+
+To update your database schema, you should run the following commands:
+
+```shell
+php artisan vendor:publish --tag="spark-migrations"
+
+php artisan migrate
+```
+
 ## Upgrading to Spark (Stripe) 5.0 From 4.x
 
 Spark (Stripe) 5.0 primarily provides an upgrade from Cashier 14.x to Cashier 15.x. As such, in addition to the upgrade guide below, please consult the [Cashier 15 upgrade guide](https://github.com/laravel/cashier-stripe/blob/15.x/UPGRADE.md).

--- a/spark-stripe/upgrade.mdx
+++ b/spark-stripe/upgrade.mdx
@@ -7,7 +7,6 @@ description: 'Learn how to upgrade your Spark Stripe application.'
 
 Spark (Stripe) 6.0 primarily provides an upgrade from Cashier 15.x to Cashier 16.x. As such, in addition to the upgrade guide below, please consult the [Cashier 16 upgrade guide](https://github.com/laravel/cashier-stripe/blob/16.x/UPGRADE.md).
 
-
 ### Stripe API Version
 
 The default Stripe API version for Cashier 16 is `2025-07-30.basil`. If this is the latest Stripe API version when you upgrade to this Cashier version, then we recommend you also upgrade your Stripe API version settings in your Stripe dashboard to this version after deploying the Cashier upgrade. If this is no longer the latest Stripe API version, we recommend you do not modify your Stripe API version settings.
@@ -17,7 +16,6 @@ Older Stripe accounts (e.g., those created before Basil previews) may encounter 
 If you use the Stripe SDK directly, make sure to properly test your integration after updating.
 
 ### Database Migration Changes
-
 
 To better track usage-based billings, we've added `meter_event_name` and `meter_id` to the `subscription_items` table. The `meter_id` column is `nullable` and is cast as a string in the model.
 


### PR DESCRIPTION
Added upgrade instructions for Spark (Stripe) 6.0 and 5.0, including API version recommendations and database migration changes.