### PR TITLE
Clarify how to customize the billing portal return button URL

### DIFF
--- a/spark-paddle/configuration.mdx
+++ b/spark-paddle/configuration.mdx
@@ -245,4 +245,3 @@ Spark's billing portal displays a "Return" link that allows users to navigate ba
 ```
 
 Adjust the value to correspond to the route where you would like users to be redirected when they click the Return link in the billing portal.
-

--- a/spark-paddle/configuration.mdx
+++ b/spark-paddle/configuration.mdx
@@ -235,3 +235,14 @@ Many applications display billing terms and conditions during checkout. Spark al
 ```
 
 Once added, Spark will display a link pointing to `/terms` in the billing portal.
+
+## Defining the Return URL
+
+Spark's billing portal displays a "Return" link that allows users to navigate back to your application. By default, this link points to `/dashboard` or `/`. You may customize this by adding a `dashboard_url` configuration value in your application's `config/spark.php` configuration file:
+
+```php
+'dashboard_url' => '/dashboard',
+```
+
+Adjust the value to correspond to the route where you would like users to be redirected when they click the Return link in the billing portal.
+

--- a/spark-stripe/configuration.mdx
+++ b/spark-stripe/configuration.mdx
@@ -287,6 +287,17 @@ Many applications display billing terms and conditions during checkout. Spark al
 
 Once added, Spark will display a link pointing to `/terms` in the billing portal.
 
+## Defining the Return URL
+
+Spark's billing portal displays a "Return" link that allows users to navigate back to your application. By default, this link points to `/dashboard` or `/`. You may customize this by adding a `dashboard_url` configuration value in your application's `config/spark.php` configuration file:
+
+```php
+'dashboard_url' => '/dashboard',
+```
+
+Adjust the value to correspond to the route where you would like users to be redirected when they click the Return link in the billing portal.
+
+
 ## Invoice Emails
 
 Spark Stripe can also email subscription invoices to your customers. To enable this feature, uncomment the 'invoiceEmails' feature entry in your application's `config/spark.php` configuration file:

--- a/spark-stripe/configuration.mdx
+++ b/spark-stripe/configuration.mdx
@@ -297,7 +297,6 @@ Spark's billing portal displays a "Return" link that allows users to navigate ba
 
 Adjust the value to correspond to the route where you would like users to be redirected when they click the Return link in the billing portal.
 
-
 ## Invoice Emails
 
 Spark Stripe can also email subscription invoices to your customers. To enable this feature, uncomment the 'invoiceEmails' feature entry in your application's `config/spark.php` configuration file:


### PR DESCRIPTION
There is a return button in Spark’s billing portal. This PR clarifies how to customize the return URL.

Spark allows you to define the return URL by setting the `dashboard_url` option in `config/spark.php`, as implemented in the `src/FrontendState.php` class:

```
    protected function dashboardUrl()
    {
        if ($dashboardUrl = config('spark.dashboard_url')) {
            return $dashboardUrl;
        }

        return app('router')->has('dashboard') ? route('dashboard') : '/';
    }
```

- Adds "Defining the return URL" section in `spark-paddle/configuration.mdx`
- Adds "Defining the return URL" section in `spark-stripe/configuration.mdx`